### PR TITLE
Fix background transcription by adding immediate background execution

### DIFF
--- a/Ramble/Ramble/RambleApp.swift
+++ b/Ramble/Ramble/RambleApp.swift
@@ -23,6 +23,9 @@ struct RambleApp: App {
                         for: UIApplication.didEnterBackgroundNotification
                     )
                 ) { _ in
+                    // Immediate ~30s background time for in-flight transcription + webhook
+                    BackgroundTaskService.shared.beginImmediateBackgroundProcessing()
+                    // Also schedule deferred BGProcessingTask as fallback for retries
                     BackgroundTaskService.shared.scheduleTranscriptionTask()
                 }
                 .onReceive(

--- a/Ramble/Ramble/Services/TranscriptionQueueService.swift
+++ b/Ramble/Ramble/Services/TranscriptionQueueService.swift
@@ -12,6 +12,11 @@ final class TranscriptionQueueService: ObservableObject {
 
     @Published private(set) var isProcessing = false
 
+    /// True when any transcription or webhook work is actively running
+    var hasActiveWork: Bool {
+        isProcessing || !activeWebhookRetryTasks.isEmpty
+    }
+
     private let transcriptionService = TranscriptionService.shared
     private let storageService = StorageService.shared
     private let webhookService = WebhookService.shared


### PR DESCRIPTION
BGProcessingTask alone is unreliable for time-sensitive work — iOS defers
it at its discretion (minutes to hours). Add UIApplication.beginBackgroundTask
to get ~30s of immediate execution time when entering background, which is
enough to finish in-flight transcription API calls and webhook sends.

- Add beginImmediateBackgroundProcessing() using beginBackgroundTask API
- Call it on didEnterBackground before scheduling BGProcessingTask fallback
- Add hasActiveWork property to track both transcription and webhook activity
- Keep BGProcessingTask as fallback for retries that don't finish in time

https://claude.ai/code/session_016XbUX1dgiu16JYWKb6iCZV