### PR TITLE
Redefine vision, brand guide, and architecture spec

### DIFF
--- a/.claude/skills/ramble-backend/SKILL.md
+++ b/.claude/skills/ramble-backend/SKILL.md
@@ -50,7 +50,7 @@ Upload a new audio recording for processing.
   ```
 
 **Responses:**
-- `202 Accepted` — Recording received, processing started
+- `202 Accepted` — Recording received, processing started. If a recording with this ID already exists, the job is reset and reprocessed (idempotent).
   ```json
   {
     "id": "uuid-string",
@@ -58,7 +58,6 @@ Upload a new audio recording for processing.
   }
   ```
 - `401 Unauthorized` — Bad or missing token
-- `409 Conflict` — Recording with this ID already exists
 
 ### GET /ramble/recordings/{id}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Ramble** is a personal voice journaling iOS app for Justin. Core flow: voice recording → upload to backend → transcription + LLM extraction → searchable archive. The goal is frictionless daily capture (< 3 seconds from intent to talking) that builds a rich, searchable record of thoughts and activities.
+**Ramble** is a voice-to-text capture app for iOS + watchOS. Core flow: tap record → talk → transcript appears. The goal is frictionless capture (< 3 seconds from intent to talking) from any surface — phone, watch, CarPlay, Siri.
 
 ### Key Principles
 
-- **For Justin only** — Optimize for one person's workflow, not generic "users"
+- **Nothing ever gets lost** — Offline-first, persistent queues, clear status
 - **Capture over organization** — Messy input beats no input; structure comes later
-- **LLM-native** — Design data formats assuming LLMs will process them
-- **Plain text wins** — Markdown files, no proprietary formats or complex databases
-- **Don't overbuild** — Ship minimal, use it, iterate based on real use
+- **No user data on servers** — Privacy by architecture. No login, no accounts.
+- **Pluggable, not opinionated** — Users choose transcription provider. Webhook for downstream.
+- **Ship and iterate** — Don't overbuild. Use it, notice what's missing, add that.
 
-See `docs/VISION.md` for full product vision and iteration phases.
+See `docs/VISION.md` for product vision, `docs/BRAND.md` for brand guide.
 
 ## Build & Development
 
@@ -50,42 +50,45 @@ Ramble/
 ### Data Flow
 
 1. **Record** — AudioRecorderService captures 16kHz mono AAC audio
-2. **Upload** — SyncQueueService uploads audio + metadata to backend via RambleAPIClient
-3. **Poll** — SyncQueueService polls GET /ramble/recordings/{id} for results
-4. **Display** — Recording model updated with transcription + agent_notes from backend
+2. **Transcribe** — TranscriptionQueueService dispatches to on-device (Apple Speech) or proxy API
+3. **Store** — Transcript saved locally to Recording model
+4. **Webhook** — Optional POST of transcript to user-configured URL
 
 ### Key Services
 
 | Service | Role |
 |---------|------|
-| `RambleAPIClient` | HTTP client — multipart upload + JSON polling |
-| `SyncQueueService` | Persistent job queue — upload phase then poll phase with backoff |
-| `BackgroundTaskService` | UIKit + BGProcessingTask for background sync |
+| `TranscriptionQueueService` | Persistent job queue — single-phase transcription with retry |
+| `AppleSpeechTranscriptionService` | On-device transcription via SFSpeechRecognizer |
+| `ProxyTranscriptionService` | HTTP client — sends audio to stateless proxy API |
+| `WebhookQueueService` | Independent queue for webhook delivery |
+| `BackgroundTaskService` | UIKit + BGProcessingTask for background processing |
 | `RecordingManager` | Coordinates audio recording lifecycle |
 | `StorageService` | JSON file persistence for recordings |
 | `PhoneConnectivityService` | WatchConnectivity bridge for watch recordings |
 
 ### Models
 
-- `Recording` — Core model: id, createdAt, duration, audioFileName, status, transcription, agentNotes, lastError
-- `RecordingStatus` — recorded → uploading → processing → completed / failed
-- `UploadJob` — Two-phase job (upload then poll) with retry backoff
-- `Settings` — apiBaseURL + apiToken
+- `Recording` — Core model: id, createdAt, duration, audioFileName, status, transcription, webhookStatus, lastError
+- `RecordingStatus` — recorded → transcribing → completed / failed
+- `TranscriptionJob` — Single-phase job with retry backoff
+- `WebhookJob` — Webhook delivery job with retry
+- `Settings` — transcriptionProvider, proxyBaseURL, webhookURL, deviceId
 
 ### Tech Stack
 
 - SwiftUI for all UI
 - Deployment target: iOS 26.2, watchOS 26.2
 
-### Backend API
+### Proxy API
 
-The app communicates with a backend via 3 endpoints:
-- `POST /ramble/recordings` — Upload audio (multipart)
-- `GET /ramble/recordings/{id}` — Poll for transcription + agent notes
-- `DELETE /ramble/recordings/{id}` — Delete recording from backend
+Thin stateless function (Cloudflare Worker or similar). Receives audio, forwards to transcription provider, returns text. Stores nothing.
 
-Full API spec: `.claude/skills/ramble-backend/SKILL.md`
+- `POST /transcribe` — Multipart audio in, `{"text": "..."}` out
+- `X-Device-ID` header for usage tracking
+
+Full architecture spec: `docs/spec-architecture.md`
 
 ## Current Phase
 
-**Phase 1: Capture** — Building the recording → upload → processing flow. Focus on making it fast and reliable enough for daily use.
+**Architecture rewrite** — Migrating from backend-dependent upload→poll model to local-first transcription with optional webhook. See `docs/spec-architecture.md`.

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -1,0 +1,216 @@
+# Ramble — Brand Guide
+
+## Brand Essence
+
+**One line:** Capture your thoughts while you live your life.
+
+**What Ramble feels like:** Freedom. You're on a trail, in the car, walking the dog — and a thought hits. You tap, you talk, it's captured. You never break stride. The app is invisible. The moment is yours.
+
+**What Ramble does NOT feel like:** Productivity software. Another app demanding your attention. A screen to stare at. A system to maintain.
+
+## Brand Position
+
+Ramble is a **lifestyle brand** that happens to be an app.
+
+It lives in the same mental space as a good pair of running shoes or a reliable water bottle — something you grab without thinking, that just works, that goes where you go.
+
+Not indie dev. Not tech startup. Not "powered by AI." Just: your thoughts, captured, always.
+
+### Competitive Position
+
+| Others | Ramble |
+|--------|--------|
+| "Record a voice memo" | "Capture a thought" |
+| Sits on your phone in a folder | Lives on your wrist, in your car, on your home screen |
+| You manage files | Your thoughts become text automatically |
+| Requires setup, accounts, logins | Works immediately, no account needed |
+| Stores your data on their servers | Your data stays on your device |
+
+## Voice & Tone
+
+### How Ramble speaks:
+
+- **Calm, not excited** — No exclamation marks. No "Amazing!" No "Unlock your potential!" Just quiet confidence.
+- **Short, not clever** — Say it simply. "Tap. Talk. Done." Not "Revolutionize your thought capture workflow."
+- **Human, not corporate** — Write like a friend who found something useful, not a brand selling something.
+- **Grounded, not aspirational** — Don't promise transformation. Promise reliability. "Your thoughts, always captured."
+
+### Examples:
+
+| Instead of | Write |
+|-----------|-------|
+| "Supercharge your productivity with voice!" | "Talk. It writes it down." |
+| "Never lose a brilliant idea again!" | "Your thoughts don't disappear anymore." |
+| "AI-powered transcription technology" | "Your words, as text, instantly." |
+| "Join thousands of users" | (Don't say this. Let the product speak.) |
+
+### Tagline candidates:
+
+- "Capture while living."
+- "Talk. It's captured."
+- "Your thoughts, always."
+- "Never lose a thought."
+
+## Visual Identity
+
+### Color Palette
+
+Natural. Soft. Outdoorsy. The palette says "go outside" not "open an app."
+
+**Primary colors:**
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Stone | `#78716C` | Primary text, UI elements |
+| Warm Sand | `#D6CFC7` | Backgrounds, cards |
+| Sage | `#87A878` | Accents, success states, record button |
+| Deep Forest | `#3D5A3E` | Headers, emphasis |
+| Cream | `#F5F0EB` | Page backgrounds |
+
+**Secondary / accent:**
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Terracotta | `#C67B5C` | Warm accents, alerts |
+| Sky | `#8FAFCA` | Links, info states |
+| Dusk | `#9B8FA0` | Muted secondary text |
+| Bark | `#5C4B3C` | Dark mode text |
+
+**What to avoid:**
+- Saturated blues (too techy)
+- Neon/bright gradients (too startup)
+- Pure black on pure white (too harsh)
+- Red for primary actions (too aggressive)
+
+### Typography Direction
+
+- Clean sans-serif for UI. Nothing decorative.
+- System fonts preferred in-app (SF Pro) — fast rendering, native feel.
+- For marketing: consider a rounded, friendly sans-serif. Think: approachable, not corporate.
+- Avoid: monospace (too dev), thin weights (too delicate), all-caps (too loud).
+
+### Iconography & Logo Direction
+
+- Simple, organic shapes. Not geometric/angular.
+- A waveform that feels natural, not technical — like a breath, not a signal analyzer.
+- Could incorporate: a speech bubble dissolving into nature, a waveform that looks like a mountain ridge, a simple circle (tap target / record button).
+- The logo should work at watch-complication size. Simplicity is mandatory.
+
+### Photography & Content Style
+
+**The rule: everything is outdoors.**
+
+Scenarios that are on-brand:
+- Walking on a trail, phone in hand, talking
+- Glancing at Apple Watch on a run, recording
+- Driving with CarPlay on screen, hands on wheel
+- Sitting on a park bench, reviewing transcripts
+- Standing at a viewpoint, capturing a thought
+- Walking the dog, earbuds in, recording
+
+Scenarios that are off-brand:
+- Sitting at a desk
+- Office setting
+- Looking at a laptop
+- Dark room with screen glow
+- Any "productivity setup" aesthetic
+
+**Photo treatment:**
+- Natural light only. Golden hour, overcast, morning sun.
+- Warm tones. Slightly desaturated. Not overly edited.
+- Person is always in motion or paused mid-activity — never posed.
+- The phone/watch is visible but not the hero — the moment is the hero.
+- Wide shots that show environment > tight crops on the device.
+
+### Video Style
+
+- Short-form (15-30 seconds for social).
+- Always outdoors. Always in motion.
+- Ambient sound present — birds, footsteps, wind. Not silent.
+- Minimal text overlay. Let the visual tell the story.
+- Show the real app, real recordings, real transcripts appearing.
+- End card: logo + tagline. Simple.
+
+## Social Media
+
+### Instagram (`@rambleapp` or similar)
+
+This is the primary marketing channel. Treat it like a proper brand account.
+
+**Content mix:**
+- 60% lifestyle footage — recording in the wild, outdoors, in motion
+- 20% product shots — clean screenshots of transcript list, watch app, record screen
+- 10% tips — "Did you know you can record from your watch?" type content
+- 10% behind-the-scenes — building the app, but still keeping it aspirational
+
+**Grid aesthetic:**
+- Consistent warm/natural color grading
+- Mix of wide landscape shots and closer product shots
+- Every post should make you want to go outside
+
+**Stories / Reels:**
+- Quick demos: "Watch me capture a thought in 3 seconds"
+- POV: recording while walking, the transcript appearing
+- Timelapses: hike + all the thoughts captured along the way
+
+**Captions:**
+- Short. Conversational. No hashtag spam.
+- First line is the hook. Keep it under 2 sentences.
+- Occasional question to encourage engagement.
+
+### What NOT to post:
+
+- Code screenshots
+- "New feature dropped!" dev-log style posts
+- Memes
+- Anything that looks like a tech product account
+- Indoor/desk content
+
+## App Store Presence
+
+### Screenshots
+
+Each screenshot should look like a moment from someone's day:
+- Recording while on a walk (phone screen showing record UI)
+- Transcript appearing after a thought (list view with recent entry)
+- Watch showing record button on a wrist in motion
+- CarPlay screen on a dashboard (future)
+- Clean transcript text ready to copy
+
+**Background of each screenshot:** Blurred outdoor scene. Not device frames on white.
+
+### App Store Description (draft direction)
+
+Keep it short. Lead with the feeling, not the features.
+
+> Tap. Talk. It's captured.
+>
+> Ramble turns your spoken thoughts into text, instantly. No account. No setup. Your words stay on your device.
+>
+> Record from your phone, your watch, or your car. Every thought gets transcribed and saved — ready to copy, search, or just look back on.
+>
+> Your thoughts don't disappear anymore.
+
+### Keywords to own
+
+- voice capture
+- thought capture
+- voice to text
+- voice notes
+- speech to text journal
+- private voice recorder
+
+### Keywords to avoid associating with
+
+- AI assistant
+- productivity
+- note-taking app (we're adjacent, not in this category)
+
+## Brand Don'ts
+
+1. **Don't lead with technology.** "AI-powered transcription" is a feature, not a selling point. The selling point is "your thoughts, captured."
+2. **Don't show screens as the hero.** The hero is the person, the moment, the thought. The app is the tool.
+3. **Don't use startup language.** No "disrupting," no "10x," no "game-changing." Just: it works, it's reliable, it's yours.
+4. **Don't compete on features.** Compete on feeling. The feeling of knowing nothing gets lost.
+5. **Don't go dark mode / techy in marketing.** Save dark mode for the app. Marketing is light, warm, natural.
+6. **Don't overpromise.** "Capture your thoughts" is a promise we can keep. "Transform your life" is not.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -2,95 +2,131 @@
 
 ## What is this?
 
-A personal voice journaling app that captures daily thoughts through short voice recordings, automatically transcribes them, and extracts meaningful insights. Built for one person (Justin), optimized for his specific workflow and needs.
+Voice-to-text capture. Tap, talk, get a transcript. That's the whole thing.
+
+Ramble is an iOS + watchOS app for capturing thoughts by voice. It records, transcribes, and stores a history of everything you say. The value is speed, reliability, and a searchable text log of your spoken thoughts.
 
 ## The Problem
 
-Justin has always struggled with:
+Typing is slow. Thoughts are fast. By the time you open a notes app and start typing, you've already lost half of what you wanted to say — or you just don't bother.
 
-- Remembering what he did, thought, and felt on any given day
-- Finding time to journal — writing feels like a chore
-- Inconsistent systems — past attempts scattered across apps, formats, and abandoned habits
-- Getting value from captured data — even when he does journal, it's hard to look back and find patterns
-
-The insight: talking is easier than writing. A 2-3 minute voice ramble captures more than 20 minutes of reluctant typing ever would.
+Voice capture solves this, but existing solutions are either unreliable, require too much setup, or lock your data into a platform.
 
 ## The North Star
 
-> At the end of each day, Justin has a rich, searchable, structured record of what he did, discovered, thought about, and how he felt — without it feeling like work.
+> Quick tap → record → transcript appears → always findable. Nothing ever gets lost.
 
 The app succeeds if:
 
-- Recording feels frictionless (< 3 seconds from intent to talking)
-- The output is genuinely useful to look back on
-- The habit sticks
+- Recording starts in < 3 seconds from intent
+- Transcription is fast and accurate
+- The transcript log is easy to browse and copy from
+- It works from phone, watch, CarPlay, and Siri — wherever you are
+- Nothing ever gets lost, even offline
 
 ## Core Loop
 
 ```
-Feel like talking → Open app → Tap → Ramble → Done
+Have a thought → Tap record → Talk → Stop → Transcript appears
 ```
 
-(Behind the scenes: transcribe → extract → store)
+Later: Browse the log → Find what you said → Copy/paste it wherever you need it
 
-Later: Browse past entries → Remember, reflect, spot patterns
+## Who is this for?
 
-## What to Focus On (Iteration Priorities)
+Ramble is growing toward a product. Primary audience:
 
-### Phase 1: Capture (current)
+- **Anyone who thinks faster than they type** — capture ideas, notes, reminders, reflections by voice
+- **People who are living, not sitting at a desk** — driving, walking, running, cooking, carrying things. Moments where you can't type but you can talk.
+- **No technical knowledge required** — should work out of the box
+- **Privacy-conscious** — no login, no user data stored on servers
 
-- Get the recording → transcription → extraction flow working
-- Make it fast and reliable
-- Actually use it daily and see what's missing
+## Brand & Positioning
 
-### Phase 2: Habit Formation
+Ramble is a **lifestyle brand**, not an indie dev project.
 
-- Experiment with reminders/nudges (what time? what trigger?)
-- Widget for quick access
-- Reduce any friction discovered in Phase 1
+The core feeling: you're out in the world, living your life, and your thoughts don't get lost. The app disappears — what remains is the freedom to capture anything, anywhere.
 
-### Phase 3: Retrieval & Value
+**Brand position:** Capture while living. Not at your desk. Not in front of a screen. Out there.
 
-- Make past entries browsable and searchable
-- Surface patterns (energy trends, recurring themes)
-- Daily/weekly summaries across multiple recordings
+**Marketing approach:** All content is outdoors. Videos of recording while walking, on a run with the watch, driving with CarPlay, hiking. Never indoors. The brand lives where the user lives — outside, in motion, hands busy.
 
-### Phase 4: Integration
+**Visual direction:** Natural color palette. Soft, outdoorsy. Think earth tones, muted greens, warm neutrals. Not techy, not startup-blue. The aesthetic says "go outside" not "open another app."
 
-- Export to Obsidian (via cloud storage + Remotely Save)
-- Build knowledge graph connections
-- Cross-reference with other data sources
+**Channel:** Dedicated Instagram. Make it legit — not personal account, not dev log. A proper brand presence that evokes the lifestyle.
+
+See `docs/BRAND.md` for full brand guide.
+
+## Architecture
+
+Record → Transcribe (on-device or via proxy) → Store locally → Optionally POST to webhook.
+
+No login. No accounts. No server-side user data.
+
+**Two selling points:**
+1. Quick, easy transcription from any device — phone, watch, CarPlay, Siri. Get a log of your thoughts you can browse and copy from.
+2. First app that integrates with AI agents in a generic way. Configure a webhook, POST your transcripts to anything.
+
+Full architecture spec: `docs/spec-architecture.md`
+
+## Roadmap
+
+### Now: Reliability & Core Polish
+
+The capture flow works. Focus is making it **bulletproof**.
+
+**Watch reliability pass (top priority):**
+- Offline recording must work without connection
+- Sync queue — when connection available, sync everything; never drop a recording
+- Watch face status — show pending/syncing queue on watch
+- Phone status view — every recording shows exact status at all times
+
+**Bugs:**
+- Haptics not firing on record start/stop (code exists but broken)
+- Record button layout shift on press
+- Screen doesn't auto-update when transcript completes
+- Mic input indicator needs work
+
+**Missing:**
+- Manual retry button for stuck transcriptions
+- Transcript list polish (easy browsing + copy)
+
+### Next: New Surfaces
+
+- **CarPlay support** — record while driving
+- **Widget** — quick access from home screen
+- **Better onboarding** — non-technical users should be able to set up without help
+
+### Later: Search & Browse
+
+- Full-text search across transcripts
+- Timeline browsing
+
+### Future: Distribution
+
+- **Open source release**
+- **Business model TBD** — likely: free (BYOK / on-device) + paid (hosted transcription proxy)
 
 ## Design Principles
 
-1. **For Justin, not for "users"** — No need to generalize. Optimize for one person's preferences, workflow, and quirks. If something feels wrong, change it immediately.
+1. **Nothing ever gets lost** — Offline-first, persistent queues, clear status at all times. This is the core promise.
 
-2. **Capture over organization** — The biggest failure mode is not capturing at all. Organization can come later. Don't let perfect structure prevent messy input.
+2. **Capture over organization** — Messy input beats no input. Structure comes later.
 
-3. **LLM-native from the start** — Raw transcripts are valuable, but the real magic is in extraction, summarization, and pattern recognition. Design data formats assuming LLMs will process them.
+3. **No user data on servers** — Privacy by architecture. No login, no accounts, no server-side storage.
 
-4. **Plain text wins** — Markdown files are portable, future-proof, and greppable. Avoid proprietary formats or complex databases.
+4. **Pluggable, not opinionated** — Users choose their transcription provider. Webhook for downstream processing. Don't lock anyone in.
 
-5. **Iterate based on real use** — Don't overbuild. Ship the minimal thing, use it, notice what's missing, add that. Repeat.
-
-## What Success Looks Like
-
-- **1 week**: App works. Justin has recorded 5+ entries. Transcription and extraction feel useful.
-- **1 month**: Habit is forming. Justin reaches for the app naturally. Looking back at entries provides genuine value ("oh right, I was thinking about that").
-- **3 months**: A meaningful archive exists. Patterns emerge. The data feeds into broader personal knowledge management. Justin can't imagine not having this.
+5. **Ship and iterate** — Don't overbuild. Use it, notice what's missing, add that.
 
 ## What This is NOT
 
-- A product for other people (yet)
-- A polished, designed experience
-- A replacement for deep writing/reflection
-- A complete PKM system (it's one input into a larger system)
+- A note-taking app (it captures voice, gives you text — what you do with it is up to you)
+- An AI assistant (no built-in LLM features — webhook is the extensibility model)
+- A platform that stores your data (transcripts live on your device)
 
-## Open Questions (to answer through use)
+## Open Questions
 
-- When is the best time to record? End of day? Multiple times? On-demand only?
-- How much extraction is useful vs. noise?
-- What prompts/questions help most when starting a ramble?
-- Should state tracking (energy, mood, etc.) be explicit prompts or inferred?
-- How important is audio playback vs. just reading transcripts?
-- What's the right level of structure in the extracted output?
+- On-device vs. API transcription — what's the right default experience?
+- Business model details — how does the paid tier work exactly?
+- How much should the app help with organization, or is raw transcript log enough?

--- a/docs/spec-architecture.md
+++ b/docs/spec-architecture.md
@@ -1,0 +1,498 @@
+# Spec: Ramble Architecture
+
+> Implementation spec for the Ramble rewrite. Defines the target system — what to build.
+
+## Overview
+
+Record audio → transcribe (on-device or via proxy) → store transcript locally → optionally POST to webhook.
+
+No login. No accounts. No server-side user data. The app works out of the box with on-device transcription. Cloud API and webhook are opt-in.
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│  iPhone / Watch                                                 │
+│                                                                 │
+│  ┌──────────┐     ┌──────────────────────┐                      │
+│  │  Record   │────▶│ TranscriptionQueue   │                      │
+│  │  Audio    │     │ Service              │                      │
+│  └──────────┘     └──────────┬───────────┘                      │
+│                              │                                  │
+│                   ┌──────────┴───────────┐                      │
+│                   │                      │                      │
+│                   ▼                      ▼                      │
+│        ┌──────────────────┐   ┌──────────────────┐              │
+│        │ Apple Speech     │   │ Proxy             │              │
+│        │ (on-device)      │   │ Transcription     │              │
+│        └────────┬─────────┘   └────────┬─────────┘              │
+│                 │                      │                        │
+│                 └──────────┬───────────┘                        │
+│                            ▼                                    │
+│                 ┌──────────────────┐                             │
+│                 │ Store transcript  │                             │
+│                 │ locally (JSON)    │                             │
+│                 └────────┬─────────┘                             │
+│                          │                                      │
+│                          ▼                                      │
+│                 ┌──────────────────┐     ┌──────────────────┐   │
+│                 │ Display in app   │     │ WebhookQueue     │   │
+│                 │                  │     │ Service           │   │
+│                 └──────────────────┘     │ (optional POST)  │   │
+│                                         └──────────────────┘   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+                                              │
+                                              ▼
+                                   ┌──────────────────┐
+                                   │ User's webhook    │
+                                   │ (agent, Zapier,   │
+                                   │  n8n, etc.)       │
+                                   └──────────────────┘
+```
+
+### Watch Flow
+
+```
+Watch: Record audio → Transfer file to phone via WatchConnectivity
+Phone: Receive file → Feed into TranscriptionQueueService (same pipeline as phone recordings)
+```
+
+No changes to watch recording or transfer. The phone handles all transcription.
+
+---
+
+## Data Models
+
+### Recording
+
+```swift
+struct Recording: Identifiable, Codable, Hashable {
+    let id: UUID
+    let createdAt: Date
+    var duration: TimeInterval
+    let audioFileName: String
+    var status: RecordingStatus
+    var transcription: String?
+    var lastError: String?
+    var webhookStatus: WebhookStatus?
+}
+
+enum RecordingStatus: String, Codable {
+    case recorded       // Audio captured, ready for transcription
+    case transcribing   // Transcription in progress
+    case completed      // Transcript available
+    case failed         // Transcription failed
+}
+
+enum WebhookStatus: String, Codable {
+    case pending        // Queued for delivery
+    case sending        // Currently sending
+    case delivered      // 2xx received
+    case failed         // All retries exhausted
+    case skipped        // No webhook configured
+}
+```
+
+Webhook status is **separate** from recording status. Transcription completing shows the transcript immediately. Webhook delivery happens in the background and never blocks the UI.
+
+### TranscriptionJob
+
+Single-phase job. Replaces the old two-phase UploadJob.
+
+```swift
+struct TranscriptionJob: Identifiable, Codable {
+    let id: UUID
+    let recordingId: UUID
+    let provider: TranscriptionProvider  // Captured at enqueue time
+    var retryCount: Int
+    let createdAt: Date
+    var nextRetryAt: Date?
+
+    static let maxRetries = 5
+    // Backoff: 5s, 15s, 45s, 90s, 180s
+}
+```
+
+Provider is captured at enqueue time so mid-queue provider switches don't affect in-flight jobs.
+
+### WebhookJob
+
+```swift
+struct WebhookJob: Identifiable, Codable {
+    let id: UUID
+    let recordingId: UUID
+    var retryCount: Int
+    let createdAt: Date
+    var nextRetryAt: Date?
+
+    static let maxRetries = 3
+    // Backoff: 5s, 30s, 120s
+}
+```
+
+### Settings
+
+```swift
+enum TranscriptionProvider: String, Codable, CaseIterable {
+    case onDevice = "on_device"     // Apple Speech Recognition
+    case proxy = "proxy"            // Cloud API via proxy
+}
+
+struct Settings: Codable {
+    var transcriptionProvider: TranscriptionProvider  // Default: .onDevice
+    var proxyBaseURL: String?       // Only used when provider == .proxy
+    var webhookURL: String?         // Optional, for downstream automations
+    var deviceId: String            // Auto-generated UUID, persisted forever
+}
+```
+
+`deviceId` is generated once on first launch. Used for proxy usage tracking. Not tied to any account or personal identifier.
+
+---
+
+## Services
+
+### TranscriptionService Protocol
+
+```swift
+struct TranscriptionRequest {
+    let audioFileURL: URL
+    let recordingId: UUID
+    let duration: TimeInterval
+}
+
+struct TranscriptionResult {
+    let text: String
+}
+
+protocol TranscriptionService {
+    func transcribe(request: TranscriptionRequest) async throws -> TranscriptionResult
+}
+```
+
+### AppleSpeechTranscriptionService
+
+On-device transcription via `SFSpeechRecognizer`.
+
+- Uses `SFSpeechURLRecognitionRequest` with the audio file
+- `shouldReportPartialResults = false` — wait for final result
+- `addsPunctuation = true`
+- Handles permission requesting (`SFSpeechRecognizer.requestAuthorization`)
+- No network required
+
+```swift
+class AppleSpeechTranscriptionService: TranscriptionService {
+    func transcribe(request: TranscriptionRequest) async throws -> TranscriptionResult
+}
+```
+
+### ProxyTranscriptionService
+
+Sends audio to the stateless proxy API.
+
+- Multipart POST with audio file
+- Reads `proxyBaseURL` from Settings
+- Sends `X-Device-ID` header
+- Returns parsed transcript text
+
+```swift
+class ProxyTranscriptionService: TranscriptionService {
+    func transcribe(request: TranscriptionRequest) async throws -> TranscriptionResult
+}
+```
+
+### TranscriptionQueueService
+
+Replaces `SyncQueueService`. Single-phase job queue.
+
+**Responsibilities:**
+- Maintain persistent queue (`transcription_queue.json`)
+- Process one job at a time
+- Dispatch to correct `TranscriptionService` based on job's provider
+- Update Recording status: `recorded → transcribing → completed/failed`
+- On completion: enqueue WebhookJob if webhook configured
+- Retry with backoff on failure (5 retries max)
+
+**Public API:**
+```swift
+@MainActor
+class TranscriptionQueueService: ObservableObject {
+    static let shared = TranscriptionQueueService()
+
+    func enqueue(recordingId: UUID)
+    func retry(recordingId: UUID)
+    func resumePendingJobs()       // Scan for .recorded status, re-enqueue
+    func processNextIfNeeded()
+}
+```
+
+### WebhookQueueService
+
+Independent queue for webhook delivery.
+
+**Responsibilities:**
+- Maintain persistent queue (`webhook_queue.json`)
+- POST transcript JSON to webhook URL
+- Update Recording.webhookStatus
+- 3 retries with backoff
+- If webhook URL removed from settings while jobs queued → mark as skipped
+
+**Public API:**
+```swift
+@MainActor
+class WebhookQueueService: ObservableObject {
+    static let shared = WebhookQueueService()
+
+    func enqueue(recordingId: UUID)
+    func retry(recordingId: UUID)
+    func processNextIfNeeded()
+}
+```
+
+### TranscriptionError
+
+```swift
+enum TranscriptionError: Error, LocalizedError {
+    case audioFileNotFound
+    case recognitionUnavailable
+    case recognitionDenied
+    case noSpeechDetected
+    case proxyNotConfigured
+    case proxyError(statusCode: Int, message: String?)
+    case networkError(Error)
+}
+```
+
+---
+
+## Proxy API Contract
+
+The proxy is a thin stateless function (Cloudflare Worker or similar). It receives audio, forwards to a transcription provider (Groq, Deepgram, etc.), returns text. **Stores nothing.**
+
+### POST /transcribe
+
+**Request:**
+```
+POST /transcribe
+Content-Type: multipart/form-data; boundary=...
+X-Device-ID: <uuid>
+
+--boundary
+Content-Disposition: form-data; name="audio"; filename="recording.m4a"
+Content-Type: audio/m4a
+
+<binary audio data>
+--boundary--
+```
+
+**Success Response (200):**
+```json
+{
+  "text": "The full transcription text..."
+}
+```
+
+**Error Responses:**
+
+| Code | Meaning |
+|------|---------|
+| 400  | Bad request — no audio or unsupported format |
+| 413  | Audio file too large |
+| 429  | Rate limited — include `retry_after` in body |
+| 500  | Transcription provider error |
+| 503  | Provider unavailable |
+
+All errors return: `{"error": "description"}`
+
+### Usage Tracking
+
+The proxy logs per-request: `(device_id, timestamp, audio_duration_seconds)`. Append-only. No audio or transcript stored.
+
+This enables:
+- Rate limiting per device
+- Usage-based billing (future)
+- Abuse prevention (block device IDs)
+
+### No Auth Token
+
+No authentication. Device ID is the identity key. The proxy trusts it for rate limiting. If billing is added later, device ID maps to payment.
+
+---
+
+## Webhook Contract
+
+When a transcript completes and a webhook URL is configured, POST:
+
+```json
+{
+  "recording_id": "uuid",
+  "created_at": "2026-03-17T13:19:00Z",
+  "duration": 138.5,
+  "transcription": "The full transcript text...",
+  "device_id": "uuid"
+}
+```
+
+**To:** User-configured webhook URL
+**Method:** POST
+**Content-Type:** application/json
+**Retries:** 3 attempts with backoff (5s, 30s, 120s)
+**Success:** Any 2xx response
+
+The app does not read or store the webhook response. Whatever happens downstream is not the app's concern.
+
+---
+
+## Settings UX
+
+### Default Experience (new user)
+
+1. Open app. No setup card. No configuration.
+2. Tap record. Talk. Stop.
+3. On-device transcription runs. Transcript appears in seconds.
+4. Done.
+
+**Zero setup required.** This is a dramatic improvement over the current flow.
+
+### Settings Screen Layout
+
+```
+┌─────────────────────────────────────────┐
+│ Settings                                │
+│                                         │
+│ ── Transcription ──────────────────────│
+│                                         │
+│ Provider:  [On-Device]  [Cloud API]     │
+│                                         │
+│ (if Cloud API:)                         │
+│ Proxy URL: [________________________]   │
+│            Requests are sent here.      │
+│            No data is stored.           │
+│                                         │
+│ ── Webhook (Optional) ────────────────│
+│                                         │
+│ URL:       [________________________]   │
+│            POST transcript to this URL  │
+│            after each recording.        │
+│                                         │
+│ [Test Webhook]                          │
+│                                         │
+│ ── Stats ──────────────────────────────│
+│                                         │
+│ Recordings:  42                         │
+│ Duration:    2h 15m                     │
+│                                         │
+│ ── Data ───────────────────────────────│
+│                                         │
+│ [Export All (JSON)]                     │
+│                                         │
+│ ── Danger Zone ────────────────────────│
+│                                         │
+│ [Delete All Data]                       │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+### Removed from Settings
+- API token field
+- Connection test button
+- "Pending uploads" / "Failed uploads" language
+
+### Updated Language
+- "Pending uploads" → "Pending transcriptions"
+- "Failed uploads" → "Failed transcriptions"
+- "Syncing" → "Transcribing"
+
+---
+
+## Background Processing
+
+`BackgroundTaskService` keeps the same two mechanisms:
+
+1. **Immediate background (~30s)** — On app background, resume transcription queue + webhook queue
+2. **BGProcessingTask** — Deferred processing for jobs that didn't complete
+
+For on-device transcription: no network needed. Background processing works offline.
+For proxy transcription: set `requiresNetworkConnectivity = true` on the BGProcessingTask.
+For webhook delivery: needs network.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `Models/TranscriptionJob.swift` | Single-phase transcription job |
+| `Models/WebhookJob.swift` | Webhook delivery job |
+| `Services/TranscriptionService.swift` | Protocol + error types + request/result types |
+| `Services/AppleSpeechTranscriptionService.swift` | On-device transcription |
+| `Services/ProxyTranscriptionService.swift` | Proxy API transcription |
+| `Services/TranscriptionQueueService.swift` | Job queue (replaces SyncQueueService) |
+| `Services/WebhookQueueService.swift` | Webhook delivery queue |
+
+## Files to Delete
+
+| File | Reason |
+|------|--------|
+| `Models/UploadJob.swift` | Replaced by TranscriptionJob |
+| `Services/SyncQueueService.swift` | Replaced by TranscriptionQueueService |
+| `Services/RambleAPIClient.swift` | Replaced by ProxyTranscriptionService |
+| `Views/SetupCardView.swift` | No setup needed — app works out of the box |
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `Models/Recording.swift` | Remove agentNotes, new status enum, add webhookStatus |
+| `Models/Settings.swift` | TranscriptionProvider, proxyBaseURL, webhookURL, deviceId |
+| `Services/RecordingManager.swift` | `SyncQueueService` → `TranscriptionQueueService` |
+| `Services/PhoneConnectivityService.swift` | Same swap |
+| `Services/BackgroundTaskService.swift` | Point at new queue services |
+| `RambleApp.swift` | Point at new queue services |
+| `Views/SettingsView.swift` | New layout: provider picker, proxy URL, webhook URL |
+| `ViewModels/SettingsViewModel.swift` | New fields, remove connection test |
+| `Views/MainView.swift` | Remove SetupCardView, update banner |
+| `Views/SyncStatusBannerView.swift` | Update copy ("transcribing" not "syncing") |
+| `Views/RecordingDetailView.swift` | Remove agent notes section, add webhook status indicator |
+| `Views/RecordingRowView.swift` | Update status display |
+| `ViewModels/RecordingViewModel.swift` | Swap queue service references |
+
+---
+
+## Implementation Sequence
+
+Ordered so the project builds at each step:
+
+1. **Models** — Recording, Settings, TranscriptionJob, WebhookJob
+2. **Protocol + implementations** — TranscriptionService, AppleSpeech, Proxy
+3. **Queue services** — TranscriptionQueueService, WebhookQueueService
+4. **Wiring** — RecordingManager, PhoneConnectivity, BackgroundTask, RambleApp
+5. **UI** — Settings, MainView, DetailView, Banner, RowView, ViewModels
+6. **Delete dead code** — UploadJob, SyncQueueService, RambleAPIClient, SetupCardView
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Transcription fails | Status → failed, lastError set. User can retry. Webhook not triggered. |
+| Webhook fails | Transcript still visible. webhookStatus → failed. User can retry webhook separately. |
+| User switches provider mid-queue | In-flight jobs keep their original provider. New recordings use new provider. |
+| User removes webhook URL while jobs queued | Queued webhook jobs marked as skipped. |
+| No speech detected | Status → failed with "No speech detected" error. |
+| Offline + on-device | Works fine. No network needed. |
+| Offline + proxy | Job stays in queue. Retries when network available. |
+| Watch recording received | Enters same transcription pipeline as phone recording. |
+
+---
+
+## Open Questions (to resolve during implementation)
+
+- [ ] iOS 26 Speech Recognition — What's new? Better quality? New APIs?
+- [ ] Proxy hosting — Cloudflare Workers? Vercel? What's cheapest/simplest?
+- [ ] Audio size limits — What's the max file size the proxy should accept?
+- [ ] Rate limiting details — What limits per device? How communicated?
+- [ ] Business model — Flat fee? Usage-based? Free tier limits?


### PR DESCRIPTION
## Summary
- **VISION.md**: Rewritten — voice-to-text capture (not journaling), lifestyle brand positioning, outdoor-first marketing, simplified roadmap
- **BRAND.md**: New brand guide — voice/tone, natural color palette, photography rules, Instagram strategy, App Store presence
- **spec-architecture.md**: Full implementation spec for architecture rewrite — local-first transcription, optional webhook, proxy API contract
- **CLAUDE.md**: Updated to reflect new architecture and principles

All docs, no code changes.

## Test plan
- [ ] Review docs for consistency across VISION, BRAND, spec, and CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)