### PR TITLE
Add Cloudflare Workers transcription proxy for Groq Whisper API

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -1,0 +1,27 @@
+name: Deploy Transcription Proxy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'proxy/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: proxy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - run: npm install
+
+      - run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/proxy/.dev.vars.example
+++ b/proxy/.dev.vars.example
@@ -1,0 +1,1 @@
+GROQ_API_KEY=your-groq-api-key-here

--- a/proxy/.gitignore
+++ b/proxy/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+.dev.vars

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ramble-transcription-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0"
+  }
+}

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -1,0 +1,89 @@
+export default {
+  async fetch(request, env) {
+    // CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders() });
+    }
+
+    const url = new URL(request.url);
+
+    if (url.pathname === '/transcribe' && request.method === 'POST') {
+      return handleTranscribe(request, env);
+    }
+
+    if (url.pathname === '/health') {
+      return json({ status: 'ok' });
+    }
+
+    return json({ error: 'Not found' }, 404);
+  },
+};
+
+async function handleTranscribe(request, env) {
+  const deviceId = request.headers.get('X-Device-ID') || 'unknown';
+
+  // Parse multipart form to get the audio file
+  let formData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return json({ error: 'Invalid multipart form data' }, 400);
+  }
+
+  const audio = formData.get('audio');
+  if (!audio || !(audio instanceof File)) {
+    return json({ error: 'Missing "audio" file field' }, 400);
+  }
+
+  console.log(`[transcribe] device=${deviceId} file=${audio.name} size=${audio.size} type=${audio.type}`);
+
+  // Forward to Groq Whisper API
+  const groqForm = new FormData();
+  groqForm.append('file', audio, audio.name || 'recording.m4a');
+  groqForm.append('model', 'whisper-large-v3');
+  groqForm.append('response_format', 'json');
+
+  let groqRes;
+  try {
+    groqRes = await fetch('https://api.groq.com/openai/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${env.GROQ_API_KEY}`,
+      },
+      body: groqForm,
+    });
+  } catch (err) {
+    console.error(`[transcribe] Groq request failed: ${err.message}`);
+    return json({ error: 'Transcription service unavailable' }, 503);
+  }
+
+  if (!groqRes.ok) {
+    const errorBody = await groqRes.text();
+    console.error(`[transcribe] Groq error ${groqRes.status}: ${errorBody}`);
+    return json({ error: 'Transcription failed' }, groqRes.status >= 500 ? 502 : 400);
+  }
+
+  const result = await groqRes.json();
+
+  console.log(`[transcribe] device=${deviceId} text_length=${result.text?.length || 0}`);
+
+  return json({ text: result.text });
+}
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders(),
+    },
+  });
+}
+
+function corsHeaders() {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, X-Device-ID',
+  };
+}

--- a/proxy/wrangler.toml
+++ b/proxy/wrangler.toml
@@ -1,0 +1,6 @@
+name = "ramble-transcription-proxy"
+main = "src/index.js"
+compatibility_date = "2024-12-01"
+
+[observability]
+enabled = true


### PR DESCRIPTION
## Summary
This PR introduces a new transcription proxy service built on Cloudflare Workers that acts as a bridge between clients and the Groq Whisper API for audio transcription.

## Key Changes
- **New transcription proxy service** (`proxy/src/index.js`):
  - Implements a Cloudflare Workers handler with `/transcribe` endpoint for audio file transcription
  - Accepts multipart form data with audio files and forwards them to Groq's Whisper API
  - Includes `/health` endpoint for service status checks
  - Supports CORS with configurable headers including custom `X-Device-ID` header
  - Implements comprehensive error handling and logging with device tracking
  - Returns transcribed text in JSON format

- **Deployment configuration**:
  - Added `wrangler.toml` for Cloudflare Workers configuration with observability enabled
  - Added GitHub Actions workflow (`.github/workflows/deploy-proxy.yml`) for automated deployment on pushes to main branch
  - Configured to deploy only when changes are made to the `proxy/` directory

- **Project setup**:
  - Added `package.json` with Wrangler CLI dependency for local development and deployment
  - Added `.gitignore` to exclude node_modules, Wrangler cache, and local environment files
  - Added `.dev.vars.example` template for local development setup

## Notable Implementation Details
- Device tracking via `X-Device-ID` header for logging and monitoring
- Proper HTTP status code mapping (502 for Groq 5xx errors, 400 for client errors)
- Detailed logging of transcription requests including file metadata and result size
- CORS preflight support for cross-origin requests
- Secure API key handling through environment variables

https://claude.ai/code/session_01CKMvmXZvR53UHW1wAWVpsx