### PR TITLE
Add audio chunking for large files and long recording warnings

### DIFF
--- a/Ramble/Ramble/Services/ProxyTranscriptionService.swift
+++ b/Ramble/Ramble/Services/ProxyTranscriptionService.swift
@@ -3,6 +3,7 @@
 //  Ramble
 //
 
+import AVFoundation
 import Foundation
 
 struct ProxyTranscriptionRequest {
@@ -30,7 +31,107 @@ final class ProxyTranscriptionService {
         // Best-effort attestation before the first request
         try? await appAttestService.attestIfNeeded()
 
-        let audioData = try Data(contentsOf: request.audioURL)
+        // Check file size to determine if chunking is needed
+        let attributes = try FileManager.default.attributesOfItem(atPath: request.audioURL.path)
+        let fileSize = attributes[.size] as? Int ?? 0
+
+        if fileSize < Constants.Transcription.maxSingleUploadSize {
+            let audioData = try Data(contentsOf: request.audioURL)
+            return try await uploadAndTranscribe(
+                audioData: audioData, baseURL: baseURL, request: request,
+                deviceId: settings.deviceId
+            )
+        } else {
+            return try await transcribeChunked(
+                baseURL: baseURL, request: request, deviceId: settings.deviceId
+            )
+        }
+    }
+
+    // MARK: - Chunked Transcription
+
+    private func transcribeChunked(
+        baseURL: URL, request: ProxyTranscriptionRequest, deviceId: String
+    ) async throws -> String {
+        let chunkURLs = try await splitAudioIntoChunks(audioURL: request.audioURL)
+
+        defer {
+            for url in chunkURLs {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        var transcripts: [String] = []
+        for chunkURL in chunkURLs {
+            let audioData = try Data(contentsOf: chunkURL)
+            let text = try await uploadAndTranscribe(
+                audioData: audioData, baseURL: baseURL, request: request,
+                deviceId: deviceId
+            )
+            if !text.isEmpty {
+                transcripts.append(text)
+            }
+        }
+
+        return transcripts.joined(separator: " ")
+    }
+
+    private func splitAudioIntoChunks(audioURL: URL) async throws -> [URL] {
+        let asset = AVURLAsset(url: audioURL)
+        let duration = try await asset.load(.duration)
+        let totalSeconds = CMTimeGetSeconds(duration)
+
+        guard totalSeconds > 0 else {
+            throw TranscriptionError.recognitionFailed("Audio file has no duration")
+        }
+
+        let chunkDuration = Constants.Transcription.chunkDurationSeconds
+        var chunks: [URL] = []
+        var startSeconds: Double = 0
+
+        while startSeconds < totalSeconds {
+            let endSeconds = min(startSeconds + chunkDuration, totalSeconds)
+            let start = CMTime(seconds: startSeconds, preferredTimescale: 44100)
+            let end = CMTime(seconds: endSeconds, preferredTimescale: 44100)
+            let timeRange = CMTimeRange(start: start, end: end)
+
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(UUID().uuidString).m4a")
+
+            guard let exportSession = AVAssetExportSession(
+                asset: asset,
+                presetName: AVAssetExportPresetAppleM4A
+            ) else {
+                for chunk in chunks { try? FileManager.default.removeItem(at: chunk) }
+                throw TranscriptionError.recognitionFailed("Failed to create audio export session")
+            }
+
+            exportSession.outputURL = tempURL
+            exportSession.outputFileType = .m4a
+            exportSession.timeRange = timeRange
+
+            await exportSession.export()
+
+            guard exportSession.status == .completed else {
+                for chunk in chunks { try? FileManager.default.removeItem(at: chunk) }
+                try? FileManager.default.removeItem(at: tempURL)
+                let errorMsg = exportSession.error?.localizedDescription ?? "Unknown error"
+                throw TranscriptionError.recognitionFailed("Failed to split audio: \(errorMsg)")
+            }
+
+            chunks.append(tempURL)
+            startSeconds = endSeconds
+        }
+
+        return chunks
+    }
+
+    // MARK: - Upload
+
+    private func uploadAndTranscribe(
+        audioData: Data, baseURL: URL, request: ProxyTranscriptionRequest,
+        deviceId: String
+    ) async throws -> String {
         let url = baseURL.appendingPathComponent("transcribe")
         let boundary = UUID().uuidString
 
@@ -40,7 +141,7 @@ final class ProxyTranscriptionService {
             "multipart/form-data; boundary=\(boundary)",
             forHTTPHeaderField: "Content-Type"
         )
-        urlRequest.setValue(settings.deviceId, forHTTPHeaderField: "X-Device-ID")
+        urlRequest.setValue(deviceId, forHTTPHeaderField: "X-Device-ID")
 
         // Subscription JWS for server-side verification
         if let jws = request.jwsTransaction {

--- a/Ramble/Ramble/Utilities/Constants.swift
+++ b/Ramble/Ramble/Utilities/Constants.swift
@@ -10,4 +10,17 @@ enum Constants {
         static let sampleRate: Double = 16000
         static let numberOfChannels: Int = 1
     }
+
+    enum Recording {
+        /// Duration threshold for a soft "long recording" warning (30 minutes)
+        static let longWarningDuration: TimeInterval = 30 * 60
+    }
+
+    enum Transcription {
+        /// Maximum file size for a single cloud upload (24 MB, under Whisper's 25 MB limit)
+        static let maxSingleUploadSize = 24 * 1024 * 1024
+
+        /// Duration per chunk when splitting large audio files (20 minutes)
+        static let chunkDurationSeconds: Double = 1200
+    }
 }

--- a/Ramble/Ramble/Utilities/DateFormatters.swift
+++ b/Ramble/Ramble/Utilities/DateFormatters.swift
@@ -26,8 +26,14 @@ enum DateFormatters {
     }()
 
     static func formatDuration(_ duration: TimeInterval) -> String {
-        let minutes = Int(duration) / 60
-        let seconds = Int(duration) % 60
+        let totalSeconds = Int(duration)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
         return String(format: "%d:%02d", minutes, seconds)
     }
 

--- a/Ramble/Ramble/Views/RecordingControlsView.swift
+++ b/Ramble/Ramble/Views/RecordingControlsView.swift
@@ -14,6 +14,11 @@ struct RecordingControlsView: View {
 
     @State private var showCancelConfirmation = false
 
+    private var durationWarning: String? {
+        guard isRecording, duration >= Constants.Recording.longWarningDuration else { return nil }
+        return "Long recording"
+    }
+
     var body: some View {
         VStack(spacing: 8) {
             if isRecording {
@@ -63,11 +68,18 @@ struct RecordingControlsView: View {
                 }
             }
 
-            if isRecording, let source = inputSourceName {
-                Text("via \(source)")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                    .transition(.opacity)
+            if isRecording {
+                if let warning = durationWarning {
+                    Text(warning)
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .transition(.opacity)
+                } else if let source = inputSourceName {
+                    Text("via \(source)")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .transition(.opacity)
+                }
             }
         }
         .animation(.snappy(duration: 0.3), value: isRecording)

--- a/Ramble/watch Watch App/Views/WatchMainView.swift
+++ b/Ramble/watch Watch App/Views/WatchMainView.swift
@@ -95,6 +95,15 @@ struct WatchMainView: View {
                 Text("Recording")
                     .font(.caption)
             }
+        } else if recordingManager.isRecording
+                    && recordingManager.currentDuration >= 30 * 60 {  // 30 min warning
+            HStack(spacing: 4) {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+                Text("Long recording")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
         } else {
             Text("Ramble")
                 .font(.system(.headline, design: .serif))
@@ -183,8 +192,14 @@ struct WatchMainView: View {
     }
 
     private func formatDuration(_ duration: TimeInterval) -> String {
-        let minutes = Int(duration) / 60
-        let seconds = Int(duration) % 60
+        let totalSeconds = Int(duration)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
         return String(format: "%d:%02d", minutes, seconds)
     }
 }


### PR DESCRIPTION
## Summary
This PR enhances the transcription service to handle large audio files by splitting them into chunks, and adds user-facing warnings for long recordings across iOS and watchOS platforms.

## Key Changes

### Transcription Service Improvements
- **Audio Chunking**: Implemented automatic splitting of large audio files (>24 MB) into 20-minute chunks before uploading to the transcription service
  - Added `transcribeChunked()` method to handle chunked uploads and concatenate results
  - Added `splitAudioIntoChunks()` method using `AVAssetExportSession` to split audio by time range
  - Refactored upload logic into `uploadAndTranscribe()` for reusability
  - Added file size check to determine if chunking is needed
  - Proper cleanup of temporary chunk files via defer block

### User Interface Warnings
- **iOS Recording Controls**: Added "Long recording" warning (orange text) that appears when recording exceeds 30 minutes
- **watchOS Main View**: Added long recording indicator with warning icon when duration exceeds 30 minutes
- **Duration Formatting**: Enhanced time display to show hours:minutes:seconds format for recordings longer than 1 hour (both iOS and watchOS)

### Constants and Configuration
- Added `Recording` enum with `longWarningDuration` constant (30 minutes)
- Added `Transcription` enum with:
  - `maxSingleUploadSize`: 24 MB (under Whisper API's 25 MB limit)
  - `chunkDurationSeconds`: 1200 seconds (20 minutes per chunk)

## Implementation Details
- Uses `AVFoundation` framework for audio asset handling and export
- Maintains fixed UI layout heights to prevent button movement when warnings appear
- Temporary chunk files are automatically cleaned up after transcription
- Chunk transcripts are joined with spaces to maintain readability
- Error handling includes cleanup of partially created chunks on export failure

https://claude.ai/code/session_0114GJP4x8kaJu7JT5EorMSn