### PR TITLE
Reflect webhook delivery in recording status and log every attempt

### DIFF
--- a/Ramble/Ramble/Services/WebhookQueueService.swift
+++ b/Ramble/Ramble/Services/WebhookQueueService.swift
@@ -51,6 +51,29 @@ final class WebhookQueueService: ObservableObject {
         processNextIfNeeded()
     }
 
+    /// User-initiated webhook send. Logs the request, resets retry state, and
+    /// enqueues (or replaces) a job. Works even if a job is already queued or
+    /// waiting in backoff.
+    func resend(recordingId: UUID) {
+        let settings = settingsService.load()
+        guard settings.webhookEnabled,
+              let webhookURL = settings.webhookURL,
+              !webhookURL.isEmpty else { return }
+
+        var recordings = storageService.loadRecordings()
+        if let idx = recordings.firstIndex(where: { $0.id == recordingId }) {
+            recordings[idx].webhookStatus = .pending
+            recordings[idx].activityLog.append(ActivityEntry("Manual webhook resend requested"))
+            storageService.saveRecordings(recordings)
+        }
+
+        // Remove any existing job so the new attempt starts fresh (retry count 0)
+        queue.removeAll { $0.recordingId == recordingId }
+        queue.append(WebhookJob(recordingId: recordingId))
+        saveQueue()
+        processNextIfNeeded()
+    }
+
     func processNextIfNeeded() {
         guard !isProcessing, let job = queue.first else { return }
         processJob(job)
@@ -124,8 +147,14 @@ final class WebhookQueueService: ObservableObject {
             return
         }
 
-        // Update webhook status to sending
+        // Update webhook status to sending and log the attempt so users can see
+        // each reach-out, including ones that time out before a response.
         recordings[idx].webhookStatus = .sending
+        let attemptNumber = job.retryCount + 1
+        let attemptLabel = attemptNumber == 1
+            ? "Sending webhook…"
+            : "Sending webhook… (attempt \(attemptNumber)/\(WebhookJob.maxRetries))"
+        recordings[idx].activityLog.append(ActivityEntry(attemptLabel))
         storageService.saveRecordings(recordings)
 
         let recording = recordings[idx]

--- a/Ramble/Ramble/Views/RecordingDetailView.swift
+++ b/Ramble/Ramble/Views/RecordingDetailView.swift
@@ -128,12 +128,9 @@ struct RecordingDetailView: View {
                 Text("Transcribing")
             case .completed:
                 switch recording.webhookStatus {
-                case .sending:
+                case .pending, .sending:
                     ProgressView().scaleEffect(0.7)
                     Text("Sending webhook")
-                case .pending:
-                    Image(systemName: "paperplane")
-                    Text("Webhook queued")
                 case .failed:
                     Image(systemName: "exclamationmark.triangle.fill")
                     Text("Webhook failed")

--- a/Ramble/Ramble/Views/RecordingDetailView.swift
+++ b/Ramble/Ramble/Views/RecordingDetailView.swift
@@ -127,8 +127,20 @@ struct RecordingDetailView: View {
                 ProgressView().scaleEffect(0.7)
                 Text("Transcribing")
             case .completed:
-                Image(systemName: "checkmark.circle.fill")
-                Text("Completed")
+                switch recording.webhookStatus {
+                case .sending:
+                    ProgressView().scaleEffect(0.7)
+                    Text("Sending webhook")
+                case .pending:
+                    Image(systemName: "paperplane")
+                    Text("Webhook queued")
+                case .failed:
+                    Image(systemName: "exclamationmark.triangle.fill")
+                    Text("Webhook failed")
+                case .delivered, .none:
+                    Image(systemName: "checkmark.circle.fill")
+                    Text("Completed")
+                }
             case .failed:
                 Image(systemName: "exclamationmark.circle.fill")
                 Text("Failed")
@@ -146,7 +158,12 @@ struct RecordingDetailView: View {
         switch recording.status {
         case .recorded: return recording.lastError != nil ? .orange : .secondary
         case .transcribing: return .blue
-        case .completed: return .green
+        case .completed:
+            switch recording.webhookStatus {
+            case .sending, .pending: return .blue
+            case .failed: return .orange
+            case .delivered, .none: return .green
+            }
         case .failed: return .red
         }
     }
@@ -338,27 +355,35 @@ struct RecordingDetailView: View {
             }
 
             if recording.webhookStatus != nil && SettingsService.shared.load().webhookEnabled {
-                Button {
-                    HapticService.buttonTap()
-                    isResendingWebhook = true
-                    WebhookQueueService.shared.enqueue(recordingId: recording.id)
-                    Task {
-                        try? await Task.sleep(nanoseconds: 500_000_000)
-                        refreshRecording()
-                        isResendingWebhook = false
-                    }
-                } label: {
-                    Label {
-                        Text(isResendingWebhook ? "Sending..." : "Resend Webhook")
-                    } icon: {
-                        if isResendingWebhook {
-                            ProgressView().scaleEffect(0.8)
-                        } else {
-                            Image(systemName: "paperplane")
-                        }
-                    }
+                webhookActionRow(for: recording)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func webhookActionRow(for recording: Recording) -> some View {
+        let inFlight = isResendingWebhook || recording.webhookStatus == .sending
+
+        if inFlight {
+            HStack(spacing: 10) {
+                ProgressView().controlSize(.small)
+                Text("Sending webhook…")
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .accessibilityElement(children: .combine)
+        } else {
+            Button {
+                HapticService.buttonTap()
+                isResendingWebhook = true
+                WebhookQueueService.shared.resend(recordingId: recording.id)
+                Task {
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    refreshRecording()
+                    isResendingWebhook = false
                 }
-                .disabled(isResendingWebhook || recording.webhookStatus == .sending)
+            } label: {
+                Label("Resend Webhook", systemImage: "paperplane")
             }
         }
     }

--- a/Ramble/Ramble/Views/RecordingRowView.swift
+++ b/Ramble/Ramble/Views/RecordingRowView.swift
@@ -57,10 +57,9 @@ struct RecordingRowView: View {
         switch recording.status {
         case .completed:
             switch recording.webhookStatus {
-            case .sending, .pending:
-                Image(systemName: "paperplane")
-                    .foregroundStyle(.blue)
-                    .font(.subheadline)
+            case .pending, .sending:
+                ProgressView()
+                    .controlSize(.mini)
             case .failed:
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)

--- a/Ramble/Ramble/Views/RecordingRowView.swift
+++ b/Ramble/Ramble/Views/RecordingRowView.swift
@@ -56,9 +56,20 @@ struct RecordingRowView: View {
     private var statusIcon: some View {
         switch recording.status {
         case .completed:
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
-                .font(.subheadline)
+            switch recording.webhookStatus {
+            case .sending, .pending:
+                Image(systemName: "paperplane")
+                    .foregroundStyle(.blue)
+                    .font(.subheadline)
+            case .failed:
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.subheadline)
+            case .delivered, .none:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.subheadline)
+            }
         case .failed:
             Image(systemName: recording.isModelNotInstalled ? "arrow.down.circle.fill" : "exclamationmark.circle.fill")
                 .foregroundStyle(recording.isModelNotInstalled ? .orange : .red)


### PR DESCRIPTION
The green "Completed" badge showed as soon as transcription finished, even
if the webhook hadn't been delivered yet — giving a false sense of success.
Recordings now surface the webhook state (queued, sending, failed) on both
the detail badge and the list row, and only show the green check once the
webhook is delivered (or isn't configured).

Each webhook attempt now writes an activity entry at the moment the request
goes out, so timeouts and retries are visible — previously only responses
were logged, which hid attempts that never came back.

Replaces the disabled-looking Resend Webhook button with an inline
"Sending webhook…" row while a send is in flight. Adds a WebhookQueueService
.resend API that logs the manual request and clears any stuck job so the
new attempt starts fresh.

https://claude.ai/code/session_01WGn9BPFCNGTKvf1VT8FMv9