### PR TITLE
Fix keychain accessibility for background attestation tasks

### DIFF
--- a/Ramble/Ramble/RambleApp.swift
+++ b/Ramble/Ramble/RambleApp.swift
@@ -13,6 +13,7 @@ struct RambleApp: App {
 
     init() {
         BackgroundTaskService.shared.registerBackgroundTasks()
+        AppAttestService.shared.migrateKeychainAccessibilityIfNeeded()
         _ = PhoneConnectivityService.shared
         HapticService.prepare()
 

--- a/Ramble/Ramble/Services/AppAttestService.swift
+++ b/Ramble/Ramble/Services/AppAttestService.swift
@@ -31,6 +31,26 @@ final class AppAttestService {
         KeychainService.string(forKey: Self.isAttestedKey) == "true"
     }
 
+    // MARK: - Migration
+
+    /// Re-writes existing keychain items so they're readable while the device is
+    /// locked (post first unlock). Older installs wrote items with the default
+    /// `WhenUnlocked` accessibility, which blocked background transcription for
+    /// watch-synced recordings received while the phone was locked overnight.
+    func migrateKeychainAccessibilityIfNeeded() {
+        let migrationKey = "appAttestKeychainAccessibilityMigrated"
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: migrationKey) else { return }
+
+        if let existingKeyId = KeychainService.string(forKey: Self.keyIdKey) {
+            KeychainService.setString(existingKeyId, forKey: Self.keyIdKey)
+        }
+        if let existingIsAttested = KeychainService.string(forKey: Self.isAttestedKey) {
+            KeychainService.setString(existingIsAttested, forKey: Self.isAttestedKey)
+        }
+        defaults.set(true, forKey: migrationKey)
+    }
+
     // MARK: - Key Generation
 
     /// Generates an App Attest key if one doesn't already exist. Returns the keyId.
@@ -91,10 +111,14 @@ final class AppAttestService {
                 keyId, clientDataHash: clientDataHash
             )
             return (keyId: keyId, assertion: assertion)
-        } catch {
-            // Key may have been invalidated (e.g. after iOS restore).
-            // Reset state so a fresh attestation happens on the next attempt.
+        } catch let error as DCError where error.code == .invalidKey {
+            // The key is genuinely gone (e.g. device restore, app reinstall).
+            // Drop state so the next attempt re-attests.
             resetState()
+            return nil
+        } catch {
+            // Transient failure (network, system busy, locked-keychain edge
+            // cases). Leave attestation state intact so the retry can reuse it.
             return nil
         }
     }

--- a/Ramble/Ramble/Services/KeychainService.swift
+++ b/Ramble/Ramble/Services/KeychainService.swift
@@ -41,14 +41,18 @@ enum KeychainService {
     static func setString(_ value: String, forKey key: String) {
         let data = Data(value.utf8)
 
-        // Try to update first
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key
         ]
+        // Readable after first unlock post-boot so background tasks (e.g.
+        // overnight watch sync) can generate App Attest assertions while the
+        // device is locked. The default is `WhenUnlocked`, which blocks reads
+        // while the device is locked and causes silent attestation failures.
         let attributes: [String: Any] = [
-            kSecValueData as String: data
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ]
 
         let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
@@ -56,6 +60,7 @@ enum KeychainService {
         if updateStatus == errSecItemNotFound {
             var newItem = query
             newItem[kSecValueData as String] = data
+            newItem[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
             SecItemAdd(newItem as CFDictionary, nil)
         }
     }


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where App Attest assertions couldn't be generated in the background while the device was locked, causing silent failures for watch-synced recordings received overnight. The root cause was keychain items being stored with the default `WhenUnlocked` accessibility level, which blocks reads while the device is locked.

## Key Changes
- **KeychainService**: Updated `setString()` to store items with `AfterFirstUnlockThisDeviceOnly` accessibility instead of the default `WhenUnlocked`. This allows background tasks to read keychain items while the device is locked (post first unlock).
- **AppAttestService**: 
  - Added `migrateKeychainAccessibilityIfNeeded()` method to re-write existing keychain items with the new accessibility level on first app launch after the update
  - Improved error handling in `generateAssertion()` to distinguish between permanent key invalidation (device restore, app reinstall) and transient failures (network, system busy, locked-keychain edge cases). Only permanent failures reset attestation state; transient failures preserve state for retry.
- **RambleApp**: Added call to `migrateKeychainAccessibilityIfNeeded()` during app initialization to handle existing installations

## Implementation Details
- The migration uses a `UserDefaults` flag to ensure the keychain rewrite only happens once
- Error handling now specifically catches `DCError` with `.invalidKey` code to identify genuine key loss versus temporary failures
- The new accessibility level (`AfterFirstUnlockThisDeviceOnly`) is applied both to new items and during migration of existing items

https://claude.ai/code/session_01FqnaVe996cf8Z57Bv6Jcev