### PR TITLE
Fix Whisper prompt echo in transcripts

### DIFF
--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -176,6 +176,13 @@ async function handleTranscribe(request, env) {
   }
   const durationMs = Date.now() - startTime;
 
+  // Post-process: Whisper occasionally echoes the `prompt` (vocabulary hint)
+  // at the tail of the transcript. Deepgram uses `keyterm` instead, so only
+  // strip for Whisper-based providers.
+  if (!result.error && vocabulary && !requestedModel.startsWith('deepgram-')) {
+    result.result = stripPromptEcho(result.result, vocabulary);
+  }
+
   // Post-process: strip fillers from Whisper/OpenAI output.
   // Deepgram's default excludes fillers, so we skip it there.
   if (!result.error && removeFillerWords && !requestedModel.startsWith('deepgram-')) {
@@ -221,7 +228,7 @@ async function transcribeWithGroq(audio, modelName, options, env) {
   }
   if (options.vocabulary) {
     // Whisper `prompt` accepts up to ~224 tokens of context — names, jargon, etc.
-    groqForm.append('prompt', options.vocabulary);
+    groqForm.append('prompt', buildWhisperPrompt(options.vocabulary));
   }
 
   let groqRes;
@@ -334,7 +341,7 @@ async function transcribeWithOpenAI(audio, options, env) {
     form.append('language', options.language);
   }
   if (options.vocabulary) {
-    form.append('prompt', options.vocabulary);
+    form.append('prompt', buildWhisperPrompt(options.vocabulary));
   }
 
   let res;
@@ -545,6 +552,37 @@ function resolveDeepgramLanguage(code) {
   if (!code) return 'multi';
   if (DEEPGRAM_NOVA3_LANGUAGES.has(code)) return code;
   return 'en';
+}
+
+// Phrase the Whisper `prompt` as a complete sentence. Whisper biases toward
+// outputs that continue the prompt, so a bare comma list often gets echoed
+// into the transcript; framing it as already-complete prose reduces that.
+function buildWhisperPrompt(vocabulary) {
+  return `Names and terms that may come up: ${vocabulary}.`;
+}
+
+// Backstop for the above — if Whisper still echoes the prompt at the tail,
+// strip it. Matches either the sentence form or the bare list, requires a
+// word boundary before the match so we don't eat legitimate content.
+function stripPromptEcho(text, vocabulary) {
+  if (!text || !vocabulary) return text;
+  const trimTrailing = (s) => s.replace(/[\s.,;:!?]+$/, '');
+  const candidates = [buildWhisperPrompt(vocabulary), vocabulary]
+    .map(trimTrailing)
+    .filter(Boolean)
+    .map((c) => c.toLowerCase())
+    .sort((a, b) => b.length - a.length);
+
+  const haystackTrimmed = trimTrailing(text);
+  const haystackLower = haystackTrimmed.toLowerCase();
+
+  for (const candidate of candidates) {
+    if (!haystackLower.endsWith(candidate)) continue;
+    const cutPos = haystackTrimmed.length - candidate.length;
+    if (cutPos !== 0 && !/[\s.,;:!?]/.test(haystackTrimmed[cutPos - 1])) continue;
+    return haystackTrimmed.slice(0, cutPos).replace(/[\s,;:]+$/, '');
+  }
+  return text;
 }
 
 function stripFillerWords(text) {


### PR DESCRIPTION
## Summary
Adds logic to prevent Whisper from echoing vocabulary hints (prompts) into the final transcript, while improving how prompts are formatted to reduce the likelihood of echo in the first place.

## Key Changes
- **Prompt formatting**: Introduced `buildWhisperPrompt()` to phrase vocabulary hints as complete sentences rather than bare comma-separated lists. Whisper biases toward continuing the prompt text, so framing it as already-complete prose reduces echo likelihood.
- **Prompt echo stripping**: Added `stripPromptEcho()` function as a backstop to remove echoed prompts from transcript tails if they still occur. The function:
  - Matches both the formatted sentence form and bare vocabulary list
  - Requires word boundaries to avoid removing legitimate content
  - Handles trailing punctuation gracefully
- **Provider-specific handling**: Applied both new functions only to Whisper-based providers (OpenAI and Groq), skipping Deepgram which uses `keyterm` instead and has different behavior.

## Implementation Details
- The `stripPromptEcho()` function sorts candidate matches by length (longest first) to handle cases where vocabulary might be a substring of the formatted prompt
- Both OpenAI and Groq transcription functions now use `buildWhisperPrompt()` when appending vocabulary to the request
- Post-processing is applied after transcription completes but before filler word removal

https://claude.ai/code/session_01DUgqWY2SeRuPq4QYTCyEHz