### PR TITLE
Move OpenAI cloud transcription to GPT-Transcribe

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -5,10 +5,32 @@ on:
     branches: [main]
     paths:
       - 'proxy/**'
+  pull_request:
+    paths:
+      - 'proxy/**'
   workflow_dispatch:
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: proxy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - run: npm ci
+
+      - run: npm test
+
   deploy:
+    # A red test run must not reach production. Pull requests stop at `test`.
+    needs: test
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,11 @@ For full brand positioning, audience, tone, and messaging guidelines, see **`doc
 
 These are free features from existing providers (no extra API calls or cost):
 
-- [ ] **Deepgram auto-paragraphs** — add `paragraphs=true` to Deepgram API call; instant readability improvement for longer recordings
-- [ ] **Filler word removal toggle** — settings toggle to strip "um", "uh", etc. Deepgram supports natively; client-side regex for Groq/OpenAI
-- [ ] **Speaker diarization** — opt-in toggle. Deepgram has `diarize=true`, OpenAI has `gpt-4o-transcribe-diarize` model. Labels speakers in transcript. Great for conversations/meetings.
-- [ ] **Language hint** — language picker in settings, passed to all providers. Improves accuracy for non-English users.
+- [x] **Deepgram auto-paragraphs** — `paragraphs=true` on the Deepgram call. Groq derives paragraphs from segment timings; models that return plain text (GPT-Transcribe, Apple Speech) get sentence grouping instead.
+- [x] **Filler word removal toggle** — settings toggle. Deepgram via `filler_words`, client-side regex for Groq/OpenAI.
+- [ ] **Speaker diarization** — opt-in toggle. Deepgram has `diarize=true`, OpenAI has a separate `gpt-4o-transcribe-diarize` model (GPT-Transcribe itself doesn't do speaker labels). Great for conversations/meetings.
+- [x] **Language hint** — language picker in settings, passed to all providers. Improves accuracy for non-English users.
+- [ ] **Recording context** — GPT-Transcribe takes a free-form `prompt` describing the recording's topic or setting, separate from the keyword list. A short "what these recordings usually are" field in Settings would feed it.
 
 ### Future
 
@@ -43,6 +44,19 @@ xcodebuild -project Ramble/Ramble.xcodeproj -scheme Ramble -destination 'platfor
 # Build watch app
 xcodebuild -project Ramble/Ramble.xcodeproj -scheme "watch Watch App" -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)'
 ```
+
+### Proxy
+
+```bash
+cd proxy
+npm ci
+npm test         # Unit tests for request shaping + transcript formatting
+npm run dev      # Local Worker via wrangler
+```
+
+Tests need no credentials or Worker runtime — they cover the pure helpers in
+`src/index.js`. CI runs them on every PR touching `proxy/**` and gates the
+deploy on them.
 
 ### Website
 
@@ -123,7 +137,7 @@ Thin stateless Cloudflare Worker. Receives audio, forwards to transcription prov
 | Whisper v3 Turbo  | Groq     | Fast and accurate — best all-around (default) |
 | Whisper Large v3  | Groq     | Best for accents and multilingual audio       |
 | Nova-3            | Deepgram | Strong English accuracy, smart formatting     |
-| GPT-4o Transcribe | OpenAI   | Highest accuracy in noisy environments        |
+| GPT-Transcribe    | OpenAI   | Highest accuracy in noisy environments        |
 
 ## Pre-Launch Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ These are free features from existing providers (no extra API calls or cost):
 - [ ] **Speaker diarization** — opt-in toggle. Deepgram has `diarize=true`, OpenAI has a separate `gpt-4o-transcribe-diarize` model (GPT-Transcribe itself doesn't do speaker labels). Great for conversations/meetings.
 - [x] **Language hint** — language picker in settings, passed to all providers. Improves accuracy for non-English users.
 - [ ] **Recording context** — GPT-Transcribe takes a free-form `prompt` describing the recording's topic or setting, separate from the keyword list. A short "what these recordings usually are" field in Settings would feed it.
+- [ ] **Multiple language hints** — the picker sends one language. GPT-Transcribe accepts several via `languages[]` and Deepgram has `multi`, so a multi-select would help people who codeswitch mid-recording.
 
 ### Future
 
@@ -137,7 +138,7 @@ Thin stateless Cloudflare Worker. Receives audio, forwards to transcription prov
 | Whisper v3 Turbo  | Groq     | Fast and accurate — best all-around (default) |
 | Whisper Large v3  | Groq     | Best for accents and multilingual audio       |
 | Nova-3            | Deepgram | Strong English accuracy, smart formatting     |
-| GPT-Transcribe    | OpenAI   | Highest accuracy in noisy environments        |
+| GPT-Transcribe    | OpenAI   | Highest accuracy on noisy real-world audio    |
 
 ## Pre-Launch Checklist
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ iPhone + Apple Watch. Open source, private by design, no accounts.
 
 ## Why Ramble
 
-- **Best-in-class transcription** — Cloud models (Groq Whisper, Deepgram Nova-3, OpenAI GPT-4o Transcribe) or free on-device Apple Speech.
+- **Best-in-class transcription** — Cloud models (Groq Whisper, Deepgram Nova-3, OpenAI GPT-Transcribe) or free on-device Apple Speech.
 - **Webhook-native** — Every transcript can POST to any HTTPS endpoint. Signed requests, automatic retries.
 - **Capture on the go** — Record from Apple Watch or phone. Walk, think, talk.
 - **Private by architecture** — No accounts, no servers. Audio stays on-device unless you send it somewhere. Open source is the proof.

--- a/Ramble/Ramble/Models/Settings.swift
+++ b/Ramble/Ramble/Models/Settings.swift
@@ -182,7 +182,7 @@ enum CloudModel: String, Codable, CaseIterable, Identifiable {
     case whisperLargeV3Turbo = "whisper-large-v3-turbo"
     case whisperLargeV3 = "whisper-large-v3"
     case deepgramNova3 = "deepgram-nova-3"
-    case openAIGPT4oTranscribe = "openai-gpt-4o-transcribe"
+    case openAIGPTTranscribe = "openai-gpt-transcribe"
 
     var id: String { rawValue }
 
@@ -191,7 +191,7 @@ enum CloudModel: String, Codable, CaseIterable, Identifiable {
         case .whisperLargeV3Turbo: return "Groq Whisper v3 Turbo"
         case .whisperLargeV3: return "Groq Whisper Large v3"
         case .deepgramNova3: return "Deepgram Nova-3"
-        case .openAIGPT4oTranscribe: return "GPT-4o Transcribe"
+        case .openAIGPTTranscribe: return "GPT-Transcribe"
         }
     }
 
@@ -200,7 +200,7 @@ enum CloudModel: String, Codable, CaseIterable, Identifiable {
         case .whisperLargeV3Turbo: return "Fast & accurate default"
         case .whisperLargeV3: return "Accents & multilingual"
         case .deepgramNova3: return "Clean English formatting"
-        case .openAIGPT4oTranscribe: return "Best for noisy audio"
+        case .openAIGPTTranscribe: return "Best for noisy audio"
         }
     }
 
@@ -208,17 +208,33 @@ enum CloudModel: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .whisperLargeV3Turbo, .whisperLargeV3: return "logo-groq"
         case .deepgramNova3: return "logo-deepgram"
-        case .openAIGPT4oTranscribe: return "logo-openai"
+        case .openAIGPTTranscribe: return "logo-openai"
+        }
+    }
+
+    /// Backward-compatible decoding. Retired model IDs map to whatever replaced
+    /// them, so a stored preference survives a model swap, and an unrecognized
+    /// ID falls back to the default rather than failing the whole decode.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        switch rawValue {
+        // GPT-Transcribe replaced the gpt-4o-transcribe family.
+        case "openai-gpt-4o-transcribe":
+            self = .openAIGPTTranscribe
+        default:
+            self = CloudModel(rawValue: rawValue) ?? .whisperLargeV3Turbo
         }
     }
 
     /// Languages this model accepts as a hint (excluding `.auto`, which is
     /// always allowed). Used by the picker to show only relevant rows.
-    /// Whisper-based models cover the full enum; Nova-3 has a fixed subset.
+    /// Whisper and GPT-Transcribe both cover the full enum; Nova-3 has a
+    /// fixed subset.
     var supportedLanguages: Set<TranscriptionLanguage> {
         switch self {
-        case .whisperLargeV3Turbo, .whisperLargeV3, .openAIGPT4oTranscribe:
-            return Self.whisperLanguages
+        case .whisperLargeV3Turbo, .whisperLargeV3, .openAIGPTTranscribe:
+            return Self.broadLanguageSupport
         case .deepgramNova3:
             return Self.deepgramNova3Languages
         }
@@ -228,12 +244,15 @@ enum CloudModel: String, Codable, CaseIterable, Identifiable {
         language == .auto || supportedLanguages.contains(language)
     }
 
-    /// Whisper supports ~99 languages — the full enum is a subset of that.
-    /// Authoritative list (OpenAI / Groq both use the same Whisper model):
-    ///   https://platform.openai.com/docs/guides/speech-to-text/supported-languages
+    /// Every language in the enum. Whisper supports ~99 languages, and
+    /// GPT-Transcribe accepts ISO-639-1 codes across a comparable range
+    /// (OpenAI doesn't publish a per-model list), so the enum is a subset of
+    /// what both models take.
+    /// Authoritative lists:
     ///   https://github.com/openai/whisper#available-models-and-languages
     ///   https://console.groq.com/docs/speech-to-text
-    private static let whisperLanguages: Set<TranscriptionLanguage> =
+    ///   https://developers.openai.com/api/docs/guides/transcription
+    private static let broadLanguageSupport: Set<TranscriptionLanguage> =
         Set(TranscriptionLanguage.allCases.filter { $0 != .auto })
 
     /// Deepgram Nova-3 monolingual language codes. Mirror of

--- a/Ramble/Ramble/Services/ProxyTranscriptionService.swift
+++ b/Ramble/Ramble/Services/ProxyTranscriptionService.swift
@@ -34,21 +34,35 @@ final class ProxyTranscriptionService {
         // Best-effort attestation before the first request
         try? await appAttestService.attestIfNeeded()
 
-        // Check file size to determine if chunking is needed
+        // Providers cap both the size and the length of a single request, and
+        // at 16 kHz mono AAC the length limit is hit first by a wide margin —
+        // 25 minutes of speech is only a few MB.
         let attributes = try FileManager.default.attributesOfItem(atPath: request.audioURL.path)
         let fileSize = attributes[.size] as? Int ?? 0
+        let duration = await audioDuration(of: request.audioURL) ?? 0
 
-        if fileSize < Constants.Transcription.maxSingleUploadSize {
-            let audioData = try Data(contentsOf: request.audioURL)
-            return try await uploadAndTranscribe(
-                audioData: audioData, baseURL: baseURL, request: request,
-                deviceId: settings.deviceId
-            )
-        } else {
+        let isOversized = fileSize >= Constants.Transcription.maxSingleUploadSize
+        let isTooLong = duration > Constants.Transcription.maxSingleUploadDuration
+
+        if isOversized || isTooLong {
             return try await transcribeChunked(
                 baseURL: baseURL, request: request, deviceId: settings.deviceId
             )
         }
+
+        let audioData = try Data(contentsOf: request.audioURL)
+        return try await uploadAndTranscribe(
+            audioData: audioData, baseURL: baseURL, request: request,
+            deviceId: settings.deviceId
+        )
+    }
+
+    /// Duration in seconds, or nil when the asset can't be read — in which case
+    /// the file-size check alone decides whether to chunk.
+    private func audioDuration(of url: URL) async -> Double? {
+        guard let duration = try? await AVURLAsset(url: url).load(.duration) else { return nil }
+        let seconds = CMTimeGetSeconds(duration)
+        return seconds.isFinite && seconds > 0 ? seconds : nil
     }
 
     // MARK: - Chunked Transcription

--- a/Ramble/Ramble/Services/TranscriptionQueueService.swift
+++ b/Ramble/Ramble/Services/TranscriptionQueueService.swift
@@ -182,9 +182,13 @@ final class TranscriptionQueueService: ObservableObject {
                 )
                 rawText = try await proxyService.transcribe(request)
             } else if #available(iOS 26.0, *) {
-                rawText = try await speechAnalyzer.transcribe(audioURL: audioURL)
+                // Cloud transcripts come back paragraphed from the proxy;
+                // on-device output is one block, so group it here for parity.
+                let onDevice = try await speechAnalyzer.transcribe(audioURL: audioURL)
+                rawText = TranscriptFormatter.paragraphs(from: onDevice)
             } else {
-                rawText = try await legacySpeech.transcribe(audioURL: audioURL)
+                let onDevice = try await legacySpeech.transcribe(audioURL: audioURL)
+                rawText = TranscriptFormatter.paragraphs(from: onDevice)
             }
             let text = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
 

--- a/Ramble/Ramble/Utilities/Constants.swift
+++ b/Ramble/Ramble/Utilities/Constants.swift
@@ -20,6 +20,12 @@ enum Constants {
         /// Maximum file size for a single cloud upload (24 MB, under Whisper's 25 MB limit)
         static let maxSingleUploadSize = 24 * 1024 * 1024
 
+        /// Maximum audio length for a single cloud upload (20 minutes).
+        /// OpenAI caps one request at 25 minutes of audio, and at 16 kHz mono
+        /// AAC that limit arrives long before the 24 MB one — 24 MB is roughly
+        /// an hour and a half of speech. Recordings past this are split.
+        static let maxSingleUploadDuration: Double = 1200
+
         /// Duration per chunk when splitting large audio files (20 minutes)
         static let chunkDurationSeconds: Double = 1200
     }

--- a/Ramble/Ramble/Utilities/TranscriptFormatter.swift
+++ b/Ramble/Ramble/Utilities/TranscriptFormatter.swift
@@ -1,0 +1,78 @@
+//
+//  TranscriptFormatter.swift
+//  Ramble
+//
+
+import Foundation
+
+/// Groups a plain-text transcript into paragraphs.
+///
+/// Cloud transcripts arrive already broken up — Deepgram returns paragraphs
+/// natively, Groq derives them from segment timings, and the proxy groups
+/// sentences for models that hand back a single block. On-device transcription
+/// has no equivalent, so a long voice memo reads as one unbroken wall of text.
+/// This applies the same grouping locally, so a transcript looks the same
+/// whichever model produced it.
+///
+/// Deliberately conservative: text that is short, already paragraphed, or has
+/// no sentence boundaries to break on comes back unchanged. Thresholds mirror
+/// `formatTextIntoParagraphs` in proxy/src/index.js — keep in sync.
+enum TranscriptFormatter {
+    /// Below this length a transcript reads fine as a single block.
+    private static let minLength = 500
+
+    /// Sentences accumulate until the paragraph reaches this length.
+    private static let targetLength = 350
+
+    /// A trailing remainder shorter than this joins the preceding paragraph
+    /// rather than standing alone as a one-line orphan.
+    private static let orphanLength = 80
+
+    static func paragraphs(from text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= minLength else { return trimmed }
+
+        // Already paragraphed — leave it alone.
+        let existingBreak = trimmed.range(of: "\n[ \t]*\n", options: .regularExpression)
+        guard existingBreak == nil else { return trimmed }
+
+        let sentences = splitIntoSentences(trimmed)
+        guard sentences.count > 1 else { return trimmed }
+
+        var paragraphs: [String] = []
+        var current = ""
+
+        for sentence in sentences {
+            current = current.isEmpty ? sentence : "\(current) \(sentence)"
+            if current.count >= targetLength {
+                paragraphs.append(current)
+                current = ""
+            }
+        }
+
+        if !current.isEmpty {
+            if current.count < orphanLength, let last = paragraphs.popLast() {
+                paragraphs.append("\(last) \(current)")
+            } else {
+                paragraphs.append(current)
+            }
+        }
+
+        return paragraphs.joined(separator: "\n\n")
+    }
+
+    /// Sentence segmentation via Foundation, which handles abbreviations and
+    /// non-Latin punctuation better than splitting on terminators by hand.
+    private static func splitIntoSentences(_ text: String) -> [String] {
+        var sentences: [String] = []
+        text.enumerateSubstrings(
+            in: text.startIndex..<text.endIndex,
+            options: [.bySentences, .localized]
+        ) { substring, _, _, _ in
+            guard let sentence = substring?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !sentence.isEmpty else { return }
+            sentences.append(sentence)
+        }
+        return sentences
+    }
+}

--- a/Ramble/Ramble/ViewModels/SettingsViewModel.swift
+++ b/Ramble/Ramble/ViewModels/SettingsViewModel.swift
@@ -9,8 +9,9 @@ import SwiftUI
 
 @MainActor
 final class SettingsViewModel: ObservableObject {
-    /// Hard cap on the custom-vocabulary field. Whisper's `prompt` accepts up
-    /// to ~224 tokens (~900 chars); beyond that the provider silently
+    /// Hard cap on the custom-vocabulary field, set by the tightest provider
+    /// budget: Whisper's `prompt` accepts ~224 tokens (~900 chars) and
+    /// Deepgram's keyterms ~500 tokens, and beyond that the provider silently
     /// truncates. We clamp on input so the user sees the limit instead of
     /// getting silently lossy hints.
     static let maxVocabularyLength = 900

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -10,7 +10,7 @@ Open source, private by design, no accounts.
 
 ## What makes Ramble different
 
-1. **Best-in-class transcription** — Choose from the latest cloud models (Groq Whisper, Deepgram Nova-3, OpenAI GPT-4o Transcribe) or use Apple's on-device speech recognition. Cloud models deliver better accuracy — especially in noisy environments, with accents, or when speaking quickly — and produce cleaner punctuation and formatting. New models get added as they ship.
+1. **Best-in-class transcription** — Choose from the latest cloud models (Groq Whisper, Deepgram Nova-3, OpenAI GPT-Transcribe) or use Apple's on-device speech recognition. Cloud models deliver better accuracy — especially in noisy environments, with accents, or when speaking quickly — and produce cleaner punctuation and formatting. New models get added as they ship.
 
 2. **Webhook-native** — Every transcript can automatically POST to any HTTPS endpoint. Connect Ramble to an AI agent, a Zapier workflow, a Notion database, or your own backend. Capture your thoughts, then do something with them.
 
@@ -75,7 +75,7 @@ iOS asset names are kebab-case (`brand-red`, `onboarding-bg`, etc.); SwiftUI acc
 ## Key messages
 
 ### For transcription enthusiasts
-"The best speech-to-text models, right when they ship. Groq Whisper, Deepgram Nova-3, OpenAI GPT-4o Transcribe — pick the one that fits. Or use Apple Speech for free, on-device transcription that never leaves your phone."
+"The best speech-to-text models, right when they ship. Groq Whisper, Deepgram Nova-3, OpenAI GPT-Transcribe — pick the one that fits. Or use Apple Speech for free, on-device transcription that never leaves your phone."
 
 ### For automation builders
 "Every transcript can POST to a webhook. Connect Ramble to your agent, your workflow, or your own backend. Signed requests, automatic retries, full API docs."

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -30,7 +30,7 @@ Retired model keys keep working — `openai-gpt-4o-transcribe` resolves to `open
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `audio` | yes | The recording. The app sends 16 kHz mono AAC, chunked client-side under the 25 MB provider limit. |
+| `audio` | yes | The recording. The app sends 16 kHz mono AAC, split client-side into pieces under 24 MB and 20 minutes so every request stays inside the providers' size and length limits. |
 | `model` | no | One of the keys above. Defaults to `whisper-large-v3-turbo`. |
 | `language` | no | ISO-639-1 hint. Omit to auto-detect. |
 | `vocabulary` | no | Comma- or newline-separated names and jargon. |

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -20,7 +20,32 @@ That's it. No logging of audio or transcripts. No database. No user accounts.
 | Whisper v3 Turbo | Groq | `whisper-large-v3-turbo` (default) |
 | Whisper Large v3 | Groq | `whisper-large-v3` |
 | Nova-3 | Deepgram | `deepgram-nova-3` |
-| GPT-4o Transcribe | OpenAI | `openai-gpt-4o-transcribe` |
+| GPT-Transcribe | OpenAI | `openai-gpt-transcribe` |
+
+Retired model keys keep working — `openai-gpt-4o-transcribe` resolves to `openai-gpt-transcribe`, so app versions already on people's phones don't break when a model is replaced.
+
+## Transcription Request
+
+`POST /transcribe` takes multipart form data:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `audio` | yes | The recording. The app sends 16 kHz mono AAC, chunked client-side under the 25 MB provider limit. |
+| `model` | no | One of the keys above. Defaults to `whisper-large-v3-turbo`. |
+| `language` | no | ISO-639-1 hint. Omit to auto-detect. |
+| `vocabulary` | no | Comma- or newline-separated names and jargon. |
+| `remove_filler_words` | no | `"true"` to strip "um", "uh", and friends. |
+
+Each provider takes those hints differently, which is the reason the proxy exists rather than the app calling providers directly:
+
+| | Groq (Whisper) | Deepgram Nova-3 | OpenAI GPT-Transcribe |
+|---|---|---|---|
+| Vocabulary | `prompt` (framed as a sentence, echo stripped from the result) | one `keyterm` per term | one `keywords[]` per term |
+| Language | `language` | `language`, or `multi` to auto-detect | `languages[]` (sending `language` too is rejected) |
+| Filler words | stripped from the response | `filler_words` parameter | stripped from the response |
+| Paragraphs | from segment timings, breaking on pauses | native `paragraphs=true` | grouped from sentences — the model returns plain text with no timings |
+
+Response is `{"text": "..."}`, or `{"error": "..."}` with a 4xx/5xx status.
 
 ## Endpoints
 
@@ -126,6 +151,11 @@ On-device transcription (Apple Speech) never contacts the proxy, so it generates
 ```bash
 npm install
 npm run dev
+npm test        # Unit tests — no credentials or Worker runtime needed
 ```
+
+`npm test` covers the pure parts: model resolution, keyword sanitizing, language
+resolution, and transcript formatting. CI runs it on every PR touching `proxy/`
+and the deploy is gated on it.
 
 You'll likely want to set `DEV_BYPASS_TOKEN` as a var in `wrangler.toml` during development to skip subscription verification.

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -2,9 +2,11 @@
   "name": "ramble-transcription-proxy",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "test": "node --test \"test/**/*.test.js\""
   },
   "devDependencies": {
     "wrangler": "4.14.0"

--- a/proxy/src/analytics.js
+++ b/proxy/src/analytics.js
@@ -23,28 +23,26 @@ export async function hashDeviceId(deviceId) {
  *
  * Data point schema:
  *   index1  — hashed device ID (for unique-user queries)
- *   blob1   — model name (e.g. "whisper-large-v3-turbo")
- *   blob2   — provider (e.g. "groq", "deepgram", "openai")
+ *   blob1   — model ID (e.g. "whisper-large-v3-turbo"), canonical: requests
+ *             using a legacy alias are recorded under the model they resolve to
+ *   blob2   — provider ("groq", "deepgram", "openai")
  *   blob3   — outcome ("success" or "error")
  *   blob4   — error detail (empty on success)
  *   double1 — audio file size in bytes
  *   double2 — transcript character length (0 on error)
  *   double3 — processing duration in ms
  */
-export async function writeTranscriptionEvent(env, { deviceId, model, audioSize, textLength, durationMs, error }) {
+export async function writeTranscriptionEvent(
+  env,
+  { deviceId, model, provider, audioSize, textLength, durationMs, error },
+) {
   if (!env.USAGE_ANALYTICS) return;
 
   const hashedId = await hashDeviceId(deviceId);
 
-  const provider = model.startsWith('deepgram-')
-    ? 'deepgram'
-    : model.startsWith('openai-')
-      ? 'openai'
-      : 'groq';
-
   env.USAGE_ANALYTICS.writeDataPoint({
     indexes: [hashedId],
-    blobs: [model, provider, error ? 'error' : 'success', error || ''],
+    blobs: [model, provider || 'unknown', error ? 'error' : 'success', error || ''],
     doubles: [audioSize || 0, textLength || 0, durationMs || 0],
   });
 }

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -215,25 +215,25 @@ async function handleTranscribe(request, env) {
   }
   const durationMs = Date.now() - startTime;
 
-  // Post-process: Whisper occasionally echoes the `prompt` (keyword hint) at
-  // the tail of the transcript. Only Groq gets its hints via `prompt` —
-  // Deepgram uses `keyterm` and GPT-Transcribe uses `keywords[]`, neither of
-  // which leaks into the output.
-  if (!result.error && keywords.length > 0 && model.provider === 'groq') {
-    result.result = stripPromptEcho(result.result, keywords.join(', '));
-  }
-
-  // Post-process: strip fillers from Whisper/OpenAI output. Deepgram handles
-  // this itself via `filler_words`, so we skip it there.
-  if (!result.error && removeFillerWords && model.provider !== 'deepgram') {
-    result.result = stripFillerWords(result.result);
-  }
-
-  // Post-process: paragraph breaks. Deepgram returns them natively and Groq
-  // derives them from segment timings; GPT-Transcribe returns a single block of
-  // text, so fall back to grouping sentences. No-op when the transcript already
-  // has paragraphs or is too short to need them.
+  // --- Post-processing ---
   if (!result.error) {
+    // Whisper occasionally echoes the `prompt` (keyword hint) at the tail of
+    // the transcript. Only Groq gets its hints via `prompt` — Deepgram uses
+    // `keyterm` and GPT-Transcribe uses `keywords[]`, neither of which leaks
+    // into the output.
+    if (keywords.length > 0 && model.provider === 'groq') {
+      result.result = stripPromptEcho(result.result, keywords.join(', '));
+    }
+
+    // Deepgram filters fillers itself via `filler_words`, so we skip it there.
+    if (removeFillerWords && model.provider !== 'deepgram') {
+      result.result = stripFillerWords(result.result);
+    }
+
+    // Paragraph breaks: Deepgram returns them natively and Groq derives them
+    // from segment timings; GPT-Transcribe returns a single block of text, so
+    // fall back to grouping sentences. No-op when the transcript already has
+    // paragraphs or is too short to need them.
     result.result = formatTextIntoParagraphs(result.result);
   }
 

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -53,9 +53,9 @@ const DEEPGRAM_NOVA3_LANGUAGES = new Set([
 ]);
 
 // Filler words stripped from Whisper/OpenAI output when remove_filler_words=true.
-// Deepgram already excludes fillers by default. Conservative list — only the
-// disfluencies most users want gone, not slang ("like", "you know") which is
-// often meaningful.
+// Deepgram does its own filtering via the `filler_words` parameter. Conservative
+// list — only the disfluencies most users want gone, not slang ("like", "you
+// know") which is often meaningful.
 const FILLER_REGEX = /\b(?:um+|uh+|er+|ah+|hmm+|mhm+|uhm+|erm+)\b[\s,.;:!?]*/gi;
 
 // Keyword hints. GPT-Transcribe rejects a request outright if any keyword
@@ -194,7 +194,7 @@ async function handleTranscribe(request, env) {
   const keywords = parseKeywords(formData.get('vocabulary') || '');
   const removeFillerWords = formData.get('remove_filler_words') === 'true';
 
-  const options = { language, keywords };
+  const options = { language, keywords, removeFillerWords };
 
   console.log(
     `[transcribe] device=${deviceId} model=${model.id} lang=${language || 'auto'} keywords=${keywords.length} fillers=${removeFillerWords ? 'strip' : 'keep'} file=${audio.name} size=${audio.size}`,
@@ -223,8 +223,8 @@ async function handleTranscribe(request, env) {
     result.result = stripPromptEcho(result.result, keywords.join(', '));
   }
 
-  // Post-process: strip fillers from Whisper/OpenAI output.
-  // Deepgram's default excludes fillers, so we skip it there.
+  // Post-process: strip fillers from Whisper/OpenAI output. Deepgram handles
+  // this itself via `filler_words`, so we skip it there.
   if (!result.error && removeFillerWords && model.provider !== 'deepgram') {
     result.result = stripFillerWords(result.result);
   }
@@ -311,13 +311,8 @@ async function transcribeWithGroq(audio, modelName, options, env) {
 
 // --- Deepgram Transcription ---
 
-async function transcribeWithDeepgram(audio, options, env) {
-  if (!env.DEEPGRAM_API_KEY) {
-    return { error: 'Deepgram API key not configured', status: 503 };
-  }
-
-  const audioBuffer = await audio.arrayBuffer();
-
+/** Query string for Deepgram's `/v1/listen`. */
+function buildDeepgramParams(options) {
   const params = new URLSearchParams({
     model: 'nova-3',
     smart_format: 'true',
@@ -327,12 +322,29 @@ async function transcribeWithDeepgram(audio, options, env) {
     // user's pick is more accurate than overriding with `multi` on the chance
     // they might also speak another language.
     language: resolveDeepgramLanguage(options.language),
+    // Deepgram strips "uh" and "um" unless asked not to, so the toggle is
+    // bidirectional here: keeping fillers means opting into them explicitly.
+    // Without this, turning the setting off left Deepgram transcripts
+    // filler-free anyway, unlike every other model.
+    filler_words: options.removeFillerWords ? 'false' : 'true',
   });
+
   // Keyterm prompting is repeated once per term. Nova-3 supports it for both
   // monolingual and `multi` requests, so it applies whatever the language hint.
   for (const term of options.keywords) {
     params.append('keyterm', term);
   }
+
+  return params;
+}
+
+async function transcribeWithDeepgram(audio, options, env) {
+  if (!env.DEEPGRAM_API_KEY) {
+    return { error: 'Deepgram API key not configured', status: 503 };
+  }
+
+  const audioBuffer = await audio.arrayBuffer();
+  const params = buildDeepgramParams(options);
 
   let res;
   try {
@@ -746,6 +758,7 @@ export {
   DEFAULT_MODEL,
   resolveModel,
   parseKeywords,
+  buildDeepgramParams,
   buildWhisperPrompt,
   stripPromptEcho,
   stripFillerWords,

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -7,18 +7,38 @@ import {
   jwsSignatureToRaw,
 } from './crypto.js';
 
-const ALLOWED_MODELS = [
-  'whisper-large-v3-turbo',
-  'whisper-large-v3',
-  'deepgram-nova-3',
-  'openai-gpt-4o-transcribe',
-];
+// Model IDs the app may request, mapped to the provider that serves them and
+// that provider's own model name. Mirror of `CloudModel` in
+// Ramble/Models/Settings.swift — keep in sync.
+const MODELS = {
+  'whisper-large-v3-turbo': { provider: 'groq', upstream: 'whisper-large-v3-turbo' },
+  'whisper-large-v3': { provider: 'groq', upstream: 'whisper-large-v3' },
+  'deepgram-nova-3': { provider: 'deepgram', upstream: 'nova-3' },
+  // GPT-Transcribe replaced the gpt-4o-transcribe family (OpenAI's own Real
+  // World Audio Benchmark: 8.98% WER vs 15.21% for Whisper). Unlike the 4o
+  // models it takes structured `keywords[]`/`languages[]` hints and returns
+  // JSON only — see transcribeWithOpenAI.
+  'openai-gpt-transcribe': { provider: 'openai', upstream: 'gpt-transcribe' },
+};
 const DEFAULT_MODEL = 'whisper-large-v3-turbo';
 
-// OpenAI's `gpt-4o-transcribe` retires around June 2026; `gpt-4o-transcribe-diarize`
-// is the GA successor (retires 2027-04-16). We ignore diarization metadata and
-// extract only the plain transcript.
-const OPENAI_MODEL = 'gpt-4o-transcribe-diarize';
+// Model IDs that shipped in older app versions. Those builds are still in
+// users' hands and can't be updated retroactively, so their requests resolve
+// to the current replacement instead of failing.
+const MODEL_ALIASES = {
+  'openai-gpt-4o-transcribe': 'openai-gpt-transcribe',
+};
+
+/**
+ * Resolve a client-requested model ID to `{ id, provider, upstream }`, or null
+ * if it isn't one we serve. `id` is the canonical ID — aliases resolve to their
+ * replacement so analytics doesn't split one model across two names.
+ */
+function resolveModel(requested) {
+  const id = MODEL_ALIASES[requested] ?? requested;
+  const entry = MODELS[id];
+  return entry ? { id, ...entry } : null;
+}
 
 // Languages Deepgram Nova-3 supports as a `language=` hint. Mirror of
 // `CloudModel.deepgramNova3Languages` in Ramble/Models/Settings.swift —
@@ -37,6 +57,21 @@ const DEEPGRAM_NOVA3_LANGUAGES = new Set([
 // disfluencies most users want gone, not slang ("like", "you know") which is
 // often meaningful.
 const FILLER_REGEX = /\b(?:um+|uh+|er+|ah+|hmm+|mhm+|uhm+|erm+)\b[\s,.;:!?]*/gi;
+
+// Keyword hints. GPT-Transcribe rejects a request outright if any keyword
+// contains `<`, `>`, or a line break, and Deepgram caps keyterms at ~500 tokens
+// (~100 words) per request — so both the shape and the size are bounded here.
+// The app already clamps the field to 900 characters on input.
+const MAX_KEYWORDS = 100;
+const MAX_KEYWORD_LENGTH = 100;
+
+// Paragraph reconstruction for providers that return plain text. Below
+// PARAGRAPH_MIN_LENGTH a transcript reads fine as one block; above it,
+// sentences accumulate until a paragraph reaches PARAGRAPH_TARGET_LENGTH.
+const PARAGRAPH_MIN_LENGTH = 500;
+const PARAGRAPH_TARGET_LENGTH = 350;
+const PARAGRAPH_ORPHAN_LENGTH = 80;
+
 const APPLE_BUNDLE_ID = 'dev.goodloop.Ramble';
 const PREMIUM_PRODUCT_ID = 'dev.goodloop.ramble.premium.monthly2';
 
@@ -149,50 +184,64 @@ async function handleTranscribe(request, env) {
 
   // --- Model selection ---
   const requestedModel = formData.get('model') || DEFAULT_MODEL;
-  if (!ALLOWED_MODELS.includes(requestedModel)) {
-    return json({ error: `Invalid model. Allowed: ${ALLOWED_MODELS.join(', ')}` }, 400);
+  const model = resolveModel(requestedModel);
+  if (!model) {
+    return json({ error: `Invalid model. Allowed: ${Object.keys(MODELS).join(', ')}` }, 400);
   }
 
   // --- Optional transcription tuning ---
   const language = (formData.get('language') || '').trim().toLowerCase() || null;
-  const vocabulary = (formData.get('vocabulary') || '').trim();
+  const keywords = parseKeywords(formData.get('vocabulary') || '');
   const removeFillerWords = formData.get('remove_filler_words') === 'true';
 
-  const options = { language, vocabulary };
+  const options = { language, keywords };
 
   console.log(
-    `[transcribe] device=${deviceId} model=${requestedModel} lang=${language || 'auto'} vocab=${vocabulary ? 'yes' : 'no'} fillers=${removeFillerWords ? 'strip' : 'keep'} file=${audio.name} size=${audio.size}`,
+    `[transcribe] device=${deviceId} model=${model.id} lang=${language || 'auto'} keywords=${keywords.length} fillers=${removeFillerWords ? 'strip' : 'keep'} file=${audio.name} size=${audio.size}`,
   );
 
   // --- Route to appropriate backend ---
   const startTime = Date.now();
   let result;
-  if (requestedModel.startsWith('deepgram-')) {
-    result = await transcribeWithDeepgram(audio, options, env);
-  } else if (requestedModel.startsWith('openai-')) {
-    result = await transcribeWithOpenAI(audio, options, env);
-  } else {
-    result = await transcribeWithGroq(audio, requestedModel, options, env);
+  switch (model.provider) {
+    case 'deepgram':
+      result = await transcribeWithDeepgram(audio, options, env);
+      break;
+    case 'openai':
+      result = await transcribeWithOpenAI(audio, model.upstream, options, env);
+      break;
+    default:
+      result = await transcribeWithGroq(audio, model.upstream, options, env);
   }
   const durationMs = Date.now() - startTime;
 
-  // Post-process: Whisper occasionally echoes the `prompt` (vocabulary hint)
-  // at the tail of the transcript. Deepgram uses `keyterm` instead, so only
-  // strip for Whisper-based providers.
-  if (!result.error && vocabulary && !requestedModel.startsWith('deepgram-')) {
-    result.result = stripPromptEcho(result.result, vocabulary);
+  // Post-process: Whisper occasionally echoes the `prompt` (keyword hint) at
+  // the tail of the transcript. Only Groq gets its hints via `prompt` —
+  // Deepgram uses `keyterm` and GPT-Transcribe uses `keywords[]`, neither of
+  // which leaks into the output.
+  if (!result.error && keywords.length > 0 && model.provider === 'groq') {
+    result.result = stripPromptEcho(result.result, keywords.join(', '));
   }
 
   // Post-process: strip fillers from Whisper/OpenAI output.
   // Deepgram's default excludes fillers, so we skip it there.
-  if (!result.error && removeFillerWords && !requestedModel.startsWith('deepgram-')) {
+  if (!result.error && removeFillerWords && model.provider !== 'deepgram') {
     result.result = stripFillerWords(result.result);
+  }
+
+  // Post-process: paragraph breaks. Deepgram returns them natively and Groq
+  // derives them from segment timings; GPT-Transcribe returns a single block of
+  // text, so fall back to grouping sentences. No-op when the transcript already
+  // has paragraphs or is too short to need them.
+  if (!result.error) {
+    result.result = formatTextIntoParagraphs(result.result);
   }
 
   if (result.error) {
     writeTranscriptionEvent(env, {
       deviceId,
-      model: requestedModel,
+      model: model.id,
+      provider: model.provider,
       audioSize: audio.size,
       textLength: 0,
       durationMs,
@@ -206,7 +255,8 @@ async function handleTranscribe(request, env) {
 
   writeTranscriptionEvent(env, {
     deviceId,
-    model: requestedModel,
+    model: model.id,
+    provider: model.provider,
     audioSize: audio.size,
     textLength,
     durationMs,
@@ -226,9 +276,9 @@ async function transcribeWithGroq(audio, modelName, options, env) {
   if (options.language) {
     groqForm.append('language', options.language);
   }
-  if (options.vocabulary) {
+  if (options.keywords.length > 0) {
     // Whisper `prompt` accepts up to ~224 tokens of context — names, jargon, etc.
-    groqForm.append('prompt', buildWhisperPrompt(options.vocabulary));
+    groqForm.append('prompt', buildWhisperPrompt(options.keywords.join(', ')));
   }
 
   let groqRes;
@@ -278,16 +328,10 @@ async function transcribeWithDeepgram(audio, options, env) {
     // they might also speak another language.
     language: resolveDeepgramLanguage(options.language),
   });
-  if (options.vocabulary) {
-    // Deepgram supports `keyterm` repeated; a single comma-separated list is
-    // accepted as one term but multiple terms work better — split on commas/newlines.
-    const terms = options.vocabulary
-      .split(/[,\n]+/)
-      .map((t) => t.trim())
-      .filter(Boolean);
-    for (const term of terms) {
-      params.append('keyterm', term);
-    }
+  // Keyterm prompting is repeated once per term. Nova-3 supports it for both
+  // monolingual and `multi` requests, so it applies whatever the language hint.
+  for (const term of options.keywords) {
+    params.append('keyterm', term);
   }
 
   let res;
@@ -324,24 +368,29 @@ async function transcribeWithDeepgram(audio, options, env) {
 
 // --- OpenAI Transcription ---
 
-async function transcribeWithOpenAI(audio, options, env) {
+async function transcribeWithOpenAI(audio, upstreamModel, options, env) {
   if (!env.OPENAI_API_KEY) {
     return { error: 'OpenAI API key not configured', status: 503 };
   }
 
   const form = new FormData();
   form.append('file', audio, audio.name || 'recording.m4a');
-  form.append('model', OPENAI_MODEL);
-  // diarize model returns `diarized_json`; we ignore speaker labels and
-  // concatenate segment text. `chunking_strategy=auto` is required for audio
-  // longer than 30s.
-  form.append('response_format', 'diarized_json');
-  form.append('chunking_strategy', 'auto');
+  form.append('model', upstreamModel);
+  // `gpt-transcribe` returns JSON only — `verbose_json`, `srt` and `vtt` aren't
+  // valid for it, so no segment timings come back and paragraph breaks are
+  // reconstructed from the text instead.
+  form.append('response_format', 'json');
+  // The new models take `languages[]` (repeated, ISO-639-1) rather than
+  // Whisper's single `language`, and reject requests that send both.
   if (options.language) {
-    form.append('language', options.language);
+    form.append('languages[]', options.language);
   }
-  if (options.vocabulary) {
-    form.append('prompt', buildWhisperPrompt(options.vocabulary));
+  // Literal terms belong in `keywords[]`, not `prompt`: the model treats them
+  // as optional hints it only uses when the audio actually contains them, so
+  // there's nothing to echo back into the transcript. `prompt` stays free for
+  // describing the recording itself.
+  for (const term of options.keywords) {
+    form.append('keywords[]', term);
   }
 
   let res;
@@ -364,20 +413,14 @@ async function transcribeWithOpenAI(audio, options, env) {
 
   const data = await res.json();
 
-  // diarized_json: { segments: [{ speaker, text, start, end }, ...] }
-  // plain json: { text: "..." }
-  if (Array.isArray(data.segments) && data.segments.length > 0) {
-    const hasTimings = data.segments.every((s) => typeof s.start === 'number' && typeof s.end === 'number');
-    return {
-      result: hasTimings
-        ? formatSegmentsIntoParagraphs(data.segments)
-        : data.segments.map((s) => (s.text || '').trim()).filter(Boolean).join(' '),
-    };
+  // json: { text: "...", languages: [{ code: "en" }] }. `languages` is the
+  // model's own detection and may be an empty array — we don't use it, the
+  // transcript is all the app needs.
+  if (typeof data.text !== 'string') {
+    return { error: 'No transcript in OpenAI response', status: 502 };
   }
-  if (typeof data.text === 'string') {
-    return { result: data.text };
-  }
-  return { error: 'No transcript in OpenAI response', status: 502 };
+
+  return { result: data.text };
 }
 
 // --- Apple JWS Verification ---
@@ -545,9 +588,84 @@ function formatSegmentsIntoParagraphs(segments, pauseThreshold = 2.0) {
 }
 
 /**
- * Remove disfluencies ("um", "uh", "er", "hmm", etc.) from a transcript and
- * collapse the resulting whitespace.
+ * Group a plain-text transcript into paragraphs by grouping sentences, for
+ * providers that return text without timings. Deliberately conservative:
+ * returns the text untouched when it already has paragraph breaks, is short
+ * enough to read as one block, or has no sentence boundaries to break on.
  */
+function formatTextIntoParagraphs(text) {
+  if (!text) return text;
+
+  const trimmed = text.trim();
+  if (trimmed.length < PARAGRAPH_MIN_LENGTH) return trimmed;
+  // Already paragraphed by the provider — leave it alone.
+  if (/\n\s*\n/.test(trimmed)) return trimmed;
+
+  // Sentence = run of non-terminator characters plus its trailing terminators
+  // and any closing quote/bracket. Covers CJK terminators too.
+  const sentences = trimmed.match(/[^.!?…。！？]+(?:[.!?…。！？]+["'”’)\]]*|$)/g);
+  if (!sentences || sentences.length < 2) return trimmed;
+
+  const paragraphs = [];
+  let current = '';
+
+  for (const sentence of sentences) {
+    const clean = sentence.trim();
+    if (!clean) continue;
+    current = current ? `${current} ${clean}` : clean;
+    if (current.length >= PARAGRAPH_TARGET_LENGTH) {
+      paragraphs.push(current);
+      current = '';
+    }
+  }
+
+  if (current) {
+    // Fold a stubby remainder into the previous paragraph rather than leaving
+    // a one-line orphan at the end.
+    if (paragraphs.length > 0 && current.length < PARAGRAPH_ORPHAN_LENGTH) {
+      paragraphs[paragraphs.length - 1] += ` ${current}`;
+    } else {
+      paragraphs.push(current);
+    }
+  }
+
+  return paragraphs.join('\n\n');
+}
+
+/**
+ * Normalize the user's custom-vocabulary field into discrete keyword hints.
+ *
+ * Providers take these as structured lists (`keywords[]` for GPT-Transcribe,
+ * repeated `keyterm` for Deepgram), and GPT-Transcribe rejects the whole
+ * request if any keyword is multi-line or contains `<` or `>` — so sanitize
+ * rather than trust the field.
+ */
+function parseKeywords(vocabulary) {
+  if (!vocabulary) return [];
+
+  const seen = new Set();
+  const keywords = [];
+
+  for (const raw of vocabulary.split(/[,\n\r]+/)) {
+    const term = raw
+      .replace(/[<>]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, MAX_KEYWORD_LENGTH)
+      .trim();
+    if (!term) continue;
+
+    const key = term.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    keywords.push(term);
+
+    if (keywords.length >= MAX_KEYWORDS) break;
+  }
+
+  return keywords;
+}
+
 function resolveDeepgramLanguage(code) {
   if (!code) return 'multi';
   if (DEEPGRAM_NOVA3_LANGUAGES.has(code)) return code;
@@ -585,6 +703,10 @@ function stripPromptEcho(text, vocabulary) {
   return text;
 }
 
+/**
+ * Remove disfluencies ("um", "uh", "er", "hmm", etc.) from a transcript and
+ * collapse the resulting whitespace.
+ */
 function stripFillerWords(text) {
   if (!text) return text;
   const stripped = text.replace(FILLER_REGEX, '');
@@ -613,3 +735,21 @@ function corsHeaders() {
     'Access-Control-Allow-Headers': 'Content-Type, X-Device-ID, Authorization, X-App-Attest, X-App-Attest-Key-Id',
   };
 }
+
+// --- Exported for tests (see proxy/test) ---
+// The Worker entry point is the default export above; these are the pure
+// request-shaping and transcript-formatting helpers, exported so `npm test`
+// can cover them without a live Worker or provider credentials.
+export {
+  MODELS,
+  MODEL_ALIASES,
+  DEFAULT_MODEL,
+  resolveModel,
+  parseKeywords,
+  buildWhisperPrompt,
+  stripPromptEcho,
+  stripFillerWords,
+  formatSegmentsIntoParagraphs,
+  formatTextIntoParagraphs,
+  resolveDeepgramLanguage,
+};

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -380,11 +380,13 @@ async function transcribeWithDeepgram(audio, options, env) {
 
 // --- OpenAI Transcription ---
 
-async function transcribeWithOpenAI(audio, upstreamModel, options, env) {
-  if (!env.OPENAI_API_KEY) {
-    return { error: 'OpenAI API key not configured', status: 503 };
-  }
-
+/**
+ * Multipart body for OpenAI's `/v1/audio/transcriptions`.
+ *
+ * Array fields are repeated with a `[]` suffix — the wire format OpenAI's own
+ * SDKs generate for `keywords` and `languages`.
+ */
+function buildOpenAIForm(audio, upstreamModel, options) {
   const form = new FormData();
   form.append('file', audio, audio.name || 'recording.m4a');
   form.append('model', upstreamModel);
@@ -404,6 +406,16 @@ async function transcribeWithOpenAI(audio, upstreamModel, options, env) {
   for (const term of options.keywords) {
     form.append('keywords[]', term);
   }
+
+  return form;
+}
+
+async function transcribeWithOpenAI(audio, upstreamModel, options, env) {
+  if (!env.OPENAI_API_KEY) {
+    return { error: 'OpenAI API key not configured', status: 503 };
+  }
+
+  const form = buildOpenAIForm(audio, upstreamModel, options);
 
   let res;
   try {
@@ -758,6 +770,7 @@ export {
   DEFAULT_MODEL,
   resolveModel,
   parseKeywords,
+  buildOpenAIForm,
   buildDeepgramParams,
   buildWhisperPrompt,
   stripPromptEcho,

--- a/proxy/test/transcribe.test.js
+++ b/proxy/test/transcribe.test.js
@@ -1,0 +1,257 @@
+// Unit tests for the proxy's pure request-shaping and transcript-formatting
+// helpers. No network, no credentials, no Worker runtime — run with `npm test`.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  MODELS,
+  MODEL_ALIASES,
+  DEFAULT_MODEL,
+  resolveModel,
+  parseKeywords,
+  buildWhisperPrompt,
+  stripPromptEcho,
+  stripFillerWords,
+  formatSegmentsIntoParagraphs,
+  formatTextIntoParagraphs,
+  resolveDeepgramLanguage,
+} from '../src/index.js';
+
+describe('resolveModel', () => {
+  it('resolves every model the app can request', () => {
+    for (const [id, entry] of Object.entries(MODELS)) {
+      assert.deepEqual(resolveModel(id), { id, ...entry });
+    }
+  });
+
+  it('routes GPT-Transcribe to OpenAI', () => {
+    assert.deepEqual(resolveModel('openai-gpt-transcribe'), {
+      id: 'openai-gpt-transcribe',
+      provider: 'openai',
+      upstream: 'gpt-transcribe',
+    });
+  });
+
+  it('maps legacy model IDs from older app builds to their replacement', () => {
+    const resolved = resolveModel('openai-gpt-4o-transcribe');
+    assert.equal(resolved.provider, 'openai');
+    assert.equal(resolved.upstream, 'gpt-transcribe');
+    // Canonical ID, so analytics doesn't split one model across two names.
+    assert.equal(resolved.id, 'openai-gpt-transcribe');
+  });
+
+  it('points every alias at a model that exists', () => {
+    for (const target of Object.values(MODEL_ALIASES)) {
+      assert.ok(MODELS[target], `alias target ${target} is not a known model`);
+    }
+  });
+
+  it('rejects unknown models', () => {
+    assert.equal(resolveModel('gpt-5-audio'), null);
+    assert.equal(resolveModel(''), null);
+  });
+
+  it('has a default model that resolves', () => {
+    assert.ok(resolveModel(DEFAULT_MODEL));
+  });
+});
+
+describe('parseKeywords', () => {
+  it('splits on commas and newlines', () => {
+    assert.deepEqual(parseKeywords('Goodloop, Ramble\nCloudflare Workers'), [
+      'Goodloop',
+      'Ramble',
+      'Cloudflare Workers',
+    ]);
+  });
+
+  it('returns an empty list for empty input', () => {
+    assert.deepEqual(parseKeywords(''), []);
+    assert.deepEqual(parseKeywords('   ,,  \n '), []);
+  });
+
+  it('strips angle brackets, which GPT-Transcribe rejects outright', () => {
+    assert.deepEqual(parseKeywords('<Ramble>, a<b>c'), ['Ramble', 'abc']);
+  });
+
+  it('never emits a keyword containing a line break or angle bracket', () => {
+    const keywords = parseKeywords('a\r\nb, <c>\nd\re, f');
+    for (const term of keywords) {
+      assert.doesNotMatch(term, /[<>\r\n]/, `"${term}" is not a valid keyword`);
+    }
+  });
+
+  it('collapses internal whitespace', () => {
+    assert.deepEqual(parseKeywords('  Cloudflare   Workers  '), ['Cloudflare Workers']);
+  });
+
+  it('dedupes case-insensitively, keeping the first spelling', () => {
+    assert.deepEqual(parseKeywords('Ramble, ramble, RAMBLE'), ['Ramble']);
+  });
+
+  it('caps the number of keywords', () => {
+    const many = Array.from({ length: 250 }, (_, i) => `term${i}`).join(',');
+    assert.equal(parseKeywords(many).length, 100);
+  });
+
+  it('caps the length of a single keyword', () => {
+    const [term] = parseKeywords('x'.repeat(500));
+    assert.equal(term.length, 100);
+  });
+});
+
+describe('buildWhisperPrompt', () => {
+  it('frames the keyword list as a complete sentence', () => {
+    assert.equal(
+      buildWhisperPrompt('Goodloop, Ramble'),
+      'Names and terms that may come up: Goodloop, Ramble.',
+    );
+  });
+});
+
+describe('stripPromptEcho', () => {
+  const vocabulary = 'Goodloop, Ramble';
+
+  it('strips the prompt sentence when Whisper echoes it', () => {
+    const text = `Shipping the new build today. ${buildWhisperPrompt(vocabulary)}`;
+    assert.equal(stripPromptEcho(text, vocabulary), 'Shipping the new build today.');
+  });
+
+  it('strips a bare echoed list', () => {
+    assert.equal(
+      stripPromptEcho('Shipping the new build today. Goodloop, Ramble', vocabulary),
+      'Shipping the new build today.',
+    );
+  });
+
+  it('leaves the transcript alone when there is no echo', () => {
+    const text = 'Shipping the new build today.';
+    assert.equal(stripPromptEcho(text, vocabulary), text);
+  });
+
+  it('keeps a legitimate mention that only ends with a keyword', () => {
+    const text = 'I was talking to the team about Ramble';
+    assert.equal(stripPromptEcho(text, vocabulary), text);
+  });
+
+  it('does not cut mid-word', () => {
+    const text = 'We should preramble';
+    assert.equal(stripPromptEcho(text, 'ramble'), text);
+  });
+
+  it('handles empty inputs', () => {
+    assert.equal(stripPromptEcho('', vocabulary), '');
+    assert.equal(stripPromptEcho('Some text', ''), 'Some text');
+  });
+});
+
+describe('stripFillerWords', () => {
+  it('removes disfluencies', () => {
+    assert.equal(
+      stripFillerWords('Um, I think, uh, we should ship it.'),
+      'I think, we should ship it.',
+    );
+  });
+
+  it('preserves paragraph breaks', () => {
+    assert.equal(
+      stripFillerWords('Um, first thought.\n\nUh, second thought.'),
+      'first thought.\n\nsecond thought.',
+    );
+  });
+
+  it('leaves words that merely contain a filler substring', () => {
+    const text = 'The number is umbrella-shaped.';
+    assert.equal(stripFillerWords(text), text);
+  });
+
+  it('handles empty input', () => {
+    assert.equal(stripFillerWords(''), '');
+  });
+});
+
+describe('formatSegmentsIntoParagraphs', () => {
+  it('breaks on pauses longer than the threshold', () => {
+    const segments = [
+      { text: 'First thought.', start: 0, end: 2 },
+      { text: 'Still the first.', start: 2.5, end: 4 },
+      { text: 'New thought.', start: 8, end: 10 },
+    ];
+    assert.equal(
+      formatSegmentsIntoParagraphs(segments),
+      'First thought. Still the first.\n\nNew thought.',
+    );
+  });
+
+  it('returns an empty string for no segments', () => {
+    assert.equal(formatSegmentsIntoParagraphs([]), '');
+  });
+});
+
+describe('formatTextIntoParagraphs', () => {
+  const sentence = 'This is a sentence of a reasonable length that a person might actually say. ';
+
+  it('leaves short transcripts as a single block', () => {
+    const text = 'Just a quick note to self. Buy milk.';
+    assert.equal(formatTextIntoParagraphs(text), text);
+  });
+
+  it('groups sentences into paragraphs once the transcript is long', () => {
+    const result = formatTextIntoParagraphs(sentence.repeat(12));
+    const paragraphs = result.split('\n\n');
+    assert.ok(paragraphs.length > 1, 'expected multiple paragraphs');
+    for (const paragraph of paragraphs) {
+      assert.doesNotMatch(paragraph, /^\s|\s$/, 'paragraphs should be trimmed');
+    }
+  });
+
+  it('preserves every word', () => {
+    const input = sentence.repeat(12).trim();
+    const result = formatTextIntoParagraphs(input);
+    assert.equal(result.split(/\s+/).join(' '), input.split(/\s+/).join(' '));
+  });
+
+  it('leaves text that the provider already paragraphed', () => {
+    const text = `${sentence.repeat(5)}\n\n${sentence.repeat(5)}`.trim();
+    assert.equal(formatTextIntoParagraphs(text), text);
+  });
+
+  it('leaves a long transcript with no sentence boundaries alone', () => {
+    const text = 'word '.repeat(200).trim();
+    assert.equal(formatTextIntoParagraphs(text), text);
+  });
+
+  it('does not leave a stubby orphan paragraph at the end', () => {
+    const result = formatTextIntoParagraphs(`${sentence.repeat(12)}Yeah.`);
+    const paragraphs = result.split('\n\n');
+    assert.ok(paragraphs[paragraphs.length - 1].length >= 80);
+  });
+
+  it('handles empty and whitespace input', () => {
+    assert.equal(formatTextIntoParagraphs(''), '');
+    assert.equal(formatTextIntoParagraphs('   '), '');
+  });
+
+  it('breaks on CJK sentence terminators', () => {
+    const cjk = '今日は新しいビルドを出荷します。'.repeat(60);
+    const result = formatTextIntoParagraphs(cjk);
+    assert.ok(result.includes('\n\n'), 'expected paragraph breaks in CJK text');
+  });
+});
+
+describe('resolveDeepgramLanguage', () => {
+  it('uses multilingual mode when no language is set', () => {
+    assert.equal(resolveDeepgramLanguage(null), 'multi');
+    assert.equal(resolveDeepgramLanguage(''), 'multi');
+  });
+
+  it('passes supported languages through verbatim', () => {
+    assert.equal(resolveDeepgramLanguage('de'), 'de');
+    assert.equal(resolveDeepgramLanguage('ja'), 'ja');
+  });
+
+  it('falls back to English for languages Nova-3 does not support', () => {
+    assert.equal(resolveDeepgramLanguage('cy'), 'en');
+  });
+});

--- a/proxy/test/transcribe.test.js
+++ b/proxy/test/transcribe.test.js
@@ -10,6 +10,7 @@ import {
   DEFAULT_MODEL,
   resolveModel,
   parseKeywords,
+  buildOpenAIForm,
   buildDeepgramParams,
   buildWhisperPrompt,
   stripPromptEcho,
@@ -238,6 +239,55 @@ describe('formatTextIntoParagraphs', () => {
     const cjk = '今日は新しいビルドを出荷します。'.repeat(60);
     const result = formatTextIntoParagraphs(cjk);
     assert.ok(result.includes('\n\n'), 'expected paragraph breaks in CJK text');
+  });
+});
+
+describe('buildOpenAIForm', () => {
+  const audio = new File([new Uint8Array([1, 2, 3])], 'recording.m4a', { type: 'audio/m4a' });
+  const options = { language: null, keywords: [], removeFillerWords: false };
+  const build = (overrides = {}) =>
+    buildOpenAIForm(audio, 'gpt-transcribe', { ...options, ...overrides });
+
+  it('sends the audio and the model', () => {
+    const form = build();
+    assert.ok(form.get('file') instanceof File);
+    assert.equal(form.get('model'), 'gpt-transcribe');
+  });
+
+  it('asks for json — the only format gpt-transcribe returns', () => {
+    assert.equal(build().get('response_format'), 'json');
+  });
+
+  it('sends the language hint as a repeated languages[] field', () => {
+    const form = build({ language: 'fr' });
+    assert.deepEqual(form.getAll('languages[]'), ['fr']);
+  });
+
+  it('never sends the legacy language field, which the model rejects alongside languages', () => {
+    assert.equal(build({ language: 'fr' }).get('language'), null);
+  });
+
+  it('omits the language field entirely when auto-detecting', () => {
+    const form = build();
+    assert.deepEqual(form.getAll('languages[]'), []);
+    assert.equal(form.get('language'), null);
+  });
+
+  it('sends one keywords[] entry per keyword', () => {
+    const form = build({ keywords: ['Goodloop', 'AC-42'] });
+    assert.deepEqual(form.getAll('keywords[]'), ['Goodloop', 'AC-42']);
+  });
+
+  it('does not put keywords in the prompt, which the model can echo back', () => {
+    assert.equal(build({ keywords: ['Goodloop'] }).get('prompt'), null);
+  });
+
+  it('sends no keyword fields when the vocabulary is empty', () => {
+    assert.deepEqual(build().getAll('keywords[]'), []);
+  });
+
+  it('does not send chunking_strategy, which only the diarize model requires', () => {
+    assert.equal(build().get('chunking_strategy'), null);
   });
 });
 

--- a/proxy/test/transcribe.test.js
+++ b/proxy/test/transcribe.test.js
@@ -10,6 +10,7 @@ import {
   DEFAULT_MODEL,
   resolveModel,
   parseKeywords,
+  buildDeepgramParams,
   buildWhisperPrompt,
   stripPromptEcho,
   stripFillerWords,
@@ -237,6 +238,40 @@ describe('formatTextIntoParagraphs', () => {
     const cjk = '今日は新しいビルドを出荷します。'.repeat(60);
     const result = formatTextIntoParagraphs(cjk);
     assert.ok(result.includes('\n\n'), 'expected paragraph breaks in CJK text');
+  });
+});
+
+describe('buildDeepgramParams', () => {
+  const options = { language: null, keywords: [], removeFillerWords: false };
+
+  it('requests Nova-3 with smart formatting and paragraphs', () => {
+    const params = buildDeepgramParams(options);
+    assert.equal(params.get('model'), 'nova-3');
+    assert.equal(params.get('smart_format'), 'true');
+    assert.equal(params.get('paragraphs'), 'true');
+  });
+
+  it('opts into filler words when the user is not removing them', () => {
+    assert.equal(buildDeepgramParams(options).get('filler_words'), 'true');
+  });
+
+  it('opts out of filler words when the user is removing them', () => {
+    const params = buildDeepgramParams({ ...options, removeFillerWords: true });
+    assert.equal(params.get('filler_words'), 'false');
+  });
+
+  it('sends one keyterm per keyword', () => {
+    const params = buildDeepgramParams({ ...options, keywords: ['Goodloop', 'Ramble'] });
+    assert.deepEqual(params.getAll('keyterm'), ['Goodloop', 'Ramble']);
+  });
+
+  it('sends no keyterm when there are no keywords', () => {
+    assert.deepEqual(buildDeepgramParams(options).getAll('keyterm'), []);
+  });
+
+  it('passes the resolved language hint', () => {
+    assert.equal(buildDeepgramParams(options).get('language'), 'multi');
+    assert.equal(buildDeepgramParams({ ...options, language: 'de' }).get('language'), 'de');
   });
 });
 

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -119,7 +119,7 @@ export default function Home() {
               </div>
               <h3 className="mt-4 text-base font-semibold text-stone-900">Best-in-class transcription</h3>
               <p className="mt-2 text-sm leading-relaxed text-stone-500">
-                Choose from the latest cloud models — Groq Whisper, Deepgram Nova-3, OpenAI GPT-4o Transcribe — or use
+                Choose from the latest cloud models — Groq Whisper, Deepgram Nova-3, OpenAI GPT-Transcribe — or use
                 free on-device Apple Speech. New models added as they ship.
               </p>
             </div>
@@ -202,7 +202,7 @@ export default function Home() {
               </summary>
               <div className="pb-5 text-sm leading-relaxed text-stone-500">
                 Yes — on-device transcription via Apple Speech and webhook delivery are completely free. Cloud
-                transcription models (Groq Whisper, Deepgram Nova-3, OpenAI GPT-4o) are an optional{" "}
+                transcription models (Groq Whisper, Deepgram Nova-3, OpenAI GPT-Transcribe) are an optional{" "}
                 <span className="text-stone-700">$3.99/month</span> subscription.
               </div>
             </details>
@@ -244,7 +244,7 @@ export default function Home() {
               </summary>
               <div className="pb-5 text-sm leading-relaxed text-stone-500">
                 On-device uses Apple Speech — free, works offline, accuracy varies by device. Cloud routes audio through
-                the model you pick (Whisper, Nova-3, GPT-4o) for sharper transcripts on accents, technical terms, and
+                the model you pick (Whisper, Nova-3, GPT-Transcribe) for sharper transcripts on accents, technical terms, and
                 noisy environments.
               </div>
             </details>


### PR DESCRIPTION
OpenAI replaced the `gpt-4o-transcribe` family with **GPT-Transcribe** — 8.98% word error rate on their Real World Audio Benchmark against 15.21% for Whisper, with better handling of short phrases, numbers, specialized terminology, and speech over loud background noise. The old model is gone from the app rather than kept alongside.

It isn't a drop-in model swap. The request shape changed, and two of the changes fix things that were quietly working against us.

## The model swap

| | Before (`gpt-4o-transcribe-diarize`) | After (`gpt-transcribe`) |
|---|---|---|
| Vocabulary hints | Whisper's `prompt`, which the model can echo into the transcript | `keywords[]` — a structured list treated as optional hints |
| Language hint | `language` | `languages[]` (sending both is rejected) |
| Response | `diarized_json`, speaker labels discarded | `json` |
| Long audio | `chunking_strategy=auto` | not accepted; handled client-side |

Keyword hints are the biggest practical win. Whisper takes them as prose it might continue, which is why the proxy carries a `stripPromptEcho` backstop for the vocabulary list leaking into the output. GPT-Transcribe takes them as a list it only uses when the audio actually contains them — so on this provider there is nothing to leak, and the backstop is now scoped to Groq where it belongs.

Keywords are also sanitized centrally now: angle brackets and line breaks stripped (GPT-Transcribe rejects the entire request otherwise), whitespace collapsed, duplicates dropped, count and length bounded to stay inside Deepgram's ~500-token keyterm budget.

## Two bugs found along the way

**A 30-minute recording would have failed.** One OpenAI request is capped at 25 minutes of audio. The app only ever split uploads on file size — 24 MB, which at 16 kHz mono AAC is about 90 minutes of speech. The old code sent `chunking_strategy=auto`, which handled long audio server-side and hid the problem; GPT-Transcribe takes no such parameter. Uploads now split on length as well, reusing the existing chunking path. It applies to every provider rather than branching for one: a boundary every 20 minutes costs nothing in accuracy — Whisper's own context window is 30 seconds.

**The filler-word toggle did nothing on Deepgram.** Nova-3 strips "uh" and "um" on its own unless `filler_words=true` is passed, so fillers were gone whether the user asked for that or not, and Deepgram transcripts read differently from every other model's. The parameter is now driven by the setting in both directions. Note this changes Deepgram's default output: fillers are kept unless the toggle is on, matching the other models.

## Keeping transcripts readable

`diarized_json` gave us segment timings, which the proxy turned into paragraph breaks on pauses. GPT-Transcribe returns plain text, so that had to be replaced rather than dropped — a long transcript arriving as one unbroken block is a visible regression.

Sentences are now grouped into paragraphs as a final pass for any provider whose output has no paragraph breaks. Deepgram (native `paragraphs=true`) and Groq (segment timings) are unaffected — the pass is a no-op on text that already has them, is short enough to read as one block, or has no sentence boundaries to break on.

The same gap existed on-device, unrelated to this migration: Apple Speech returns one block, so a long voice memo transcribed for free looked worse than the identical recording through any cloud model. `TranscriptFormatter` applies the same grouping locally, using Foundation's sentence segmentation, which handles abbreviations and non-Latin punctuation better than splitting on terminators by hand.

## Nothing to pull in from the others

- **Groq** — `whisper-large-v3-turbo` and `whisper-large-v3` are still current; no newer STT model shipped.
- **Deepgram** — Nova-3 is still the flagship for pre-recorded audio. Flux is newer but purpose-built for voice agents (streaming, end-of-turn detection), not batch files. Keyterm prompting works with `multi` now as well as monolingual, which is what the proxy already assumed.
- **Apple Speech** — already on iOS 26's `SpeechAnalyzer`.

Default cloud model stays Groq Whisper v3 Turbo: GPT-Transcribe is roughly an order of magnitude more expensive per hour, so it stays an explicit choice rather than the default. Easy to flip if you'd rather lead with accuracy.

## Nobody's settings break

Two things on disk hold a model ID — the user's settings and any queued transcription job. The queue is loaded with `try?` over the whole array, so one unrecognized ID would have silently dropped **every** pending job on upgrade. `CloudModel` now maps the retired ID to its replacement and falls back to the default for anything unrecognized instead of failing the decode.

The proxy keeps `openai-gpt-4o-transcribe` as an alias for the same reason: app versions already on people's phones keep working, and analytics records the canonical ID so one model doesn't split across two names.

## Testing

`proxy/` had no tests. It has 53 now, covering the parts where a typo is either a rejected request or a silently worse transcript:

- the exact OpenAI multipart shape, including the negatives — no `language` alongside `languages[]`, no keywords in `prompt`, no `chunking_strategy`
- Deepgram's query string, including `filler_words` in both directions
- model resolution and legacy aliases
- keyword sanitizing, filler stripping, prompt-echo stripping, both paragraph formatters

`npm test` needs no credentials or Worker runtime. CI runs it on every PR touching `proxy/**`, and the deploy job is now gated on it — a red run can't reach production, which it could before.

**Not verified:** the iOS target doesn't compile in this environment (no Xcode), so the Swift changes are reviewed but unbuilt. Worth a build and one long on-device recording before merge. The proxy tests all pass and the website builds clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTrzS2PCiWkZ6CCzECC5N6)_